### PR TITLE
Fix event hover for Firefox

### DIFF
--- a/lib/eventDrops.js
+++ b/lib/eventDrops.js
@@ -109,11 +109,11 @@ module.exports = function (d3) {
         if (typeof config.eventHover === 'function') {
           zoomRect.on('mousemove', function(d, e) {
             var event = d3.event;
-            if (curx == event.x && cury == event.y) return;
-            curx = event.x;
-            cury = event.y;
+            if (curx == event.clientX && cury == event.clientY) return;
+            curx = event.clientX;
+            cury = event.clientY;
             zoomRect.attr('display', 'none');
-            var el = document.elementFromPoint(d3.event.x, d3.event.y);
+            var el = document.elementFromPoint(d3.event.clientX, d3.event.clientY);
             zoomRect.attr('display', 'block');
             if (el.tagName !== 'circle') return;
             config.eventHover(el);


### PR DESCRIPTION
Event hovering is currently broken in firefox. Using event.clientX/clientY instead of event.x/y fixes the issue for Firefox while still working elsewhere.
