### PR TITLE
[RFR] Render zoom handlers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Configurable values:
   - `eventColor`: The color of the event. Accepts a color (color name or `#ffffff` notation), or a function receiving the eventData and returning a color. Defaults to null. EventLineColor will be ignored if this is used.
   - `minScale`: The minimum scaling (zoom out), default to 0.
   - `maxScale`: The maximum scaling (zoom in), default to Infinity.
+  - `zoomable`: *true* by default. Enable zoom-in/zoom-out and dragging handlers.
 
 ## Styling
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,7 +33,8 @@ const config = {
     hasBottomAxis: (d) => d.length >= 10,
     eventLineColor: 'black',
     eventColor: null,
-    metaballs: true
+    metaballs: true,
+    zoomable: true
 };
 
 config.dateFormat = config.locale ? config.locale.timeFormat("%d %B %Y") : d3.time.format("%d %B %Y");

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,9 +34,9 @@ const config = {
     eventLineColor: 'black',
     eventColor: null,
     metaballs: true,
-    zoomable: true
+    zoomable: true,
 };
 
-config.dateFormat = config.locale ? config.locale.timeFormat("%d %B %Y") : d3.time.format("%d %B %Y");
+config.dateFormat = config.locale ? config.locale.timeFormat('%d %B %Y') : d3.time.format('%d %B %Y');
 
 module.exports = config;

--- a/lib/eventDrops.js
+++ b/lib/eventDrops.js
@@ -44,7 +44,9 @@ function eventDrops(config = {}) {
             const draw = drawer(svg, dimensions, scales, finalConfiguration).bind(selection);
             draw(data);
 
-            zoom(d3.select('.drops-container'), dimensions, scales, finalConfiguration, data, draw);
+            if (finalConfiguration.zoomable) {
+                zoom(d3.select(this).select('.drops-container'), dimensions, scales, finalConfiguration, data, draw);
+            }
         });
     }
 

--- a/lib/eventDrops.js
+++ b/lib/eventDrops.js
@@ -23,7 +23,7 @@ function eventDrops(config = {}) {
     };
 
     function eventDropGraph(selection) {
-        selection.each(function (data) {
+        selection.each(function selector(data) {
             const height = data.length * 40;
             const dimensions = {
                 width: finalConfiguration.width - finalConfiguration.margin.right - finalConfiguration.margin.left,
@@ -38,7 +38,7 @@ function eventDrops(config = {}) {
 
             const svg = d3.select(this).append('svg').attr({
                 width: dimensions.width,
-                height: dimensions.outer_height
+                height: dimensions.outer_height,
             });
 
             const draw = drawer(svg, dimensions, scales, finalConfiguration).bind(selection);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "babel-core": "6.4.5",
+    "babel-eslint": "^4.1.8",
     "babel-loader": "6.2.1",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-stage-0": "^6.3.13",

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -50,4 +50,19 @@ describe('d3.chart.eventDrops', () => {
 
         expect(div.querySelectorAll('.drop').length).toBe(3);
     });
+
+    it('should enable zoom only if `zoomable` configuration property is true', () => {
+        const data = [ { name: 'foo', dates: [new Date()] }];
+        const test = (zoomable, expectedZoomAreaNumber) => {
+            const div = document.createElement('div');
+
+            const chart = d3.chart.eventDrops().zoomable(zoomable);
+            d3.select(div).datum(data).call(chart);
+
+            expect(div.querySelectorAll('.zoom-area').length).toBe(expectedZoomAreaNumber);
+        };
+
+        test(false, 0);
+        test(true, 1);
+    });
 });


### PR DESCRIPTION
Zoom handlers were always enabled by default, causing sometimes some issue. This PR makes these handlers optional.

Fixes #38.