### PR TITLE
[RFR] Prevent duplicating charts on consecutive calls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,11 @@
     "rules": {
         "indent": [2, 4],
         "id-length": [2, { "min": 1 }]
+    },
+    "env": {
+        "jasmine": true
+    },
+    "globals": {
+        "d3": true
     }
 }

--- a/lib/eventDrops.js
+++ b/lib/eventDrops.js
@@ -24,6 +24,8 @@ function eventDrops(config = {}) {
 
     function eventDropGraph(selection) {
         selection.each(function selector(data) {
+            d3.select(this).select('.event-drops-chart').remove();
+
             const height = data.length * 40;
             const dimensions = {
                 width: finalConfiguration.width - finalConfiguration.margin.right - finalConfiguration.margin.left,
@@ -36,10 +38,12 @@ function eventDrops(config = {}) {
                 y: yScale(data),
             };
 
-            const svg = d3.select(this).append('svg').attr({
-                width: dimensions.width,
-                height: dimensions.outer_height,
-            });
+            const svg = d3.select(this).append('svg')
+                .classed('event-drops-chart', true)
+                .attr({
+                    width: dimensions.width,
+                    height: dimensions.outer_height,
+                });
 
             const draw = drawer(svg, dimensions, scales, finalConfiguration).bind(selection);
             draw(data);

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -8,7 +8,18 @@ describe('d3.chart.eventDrops', () => {
         const chart = d3.chart.eventDrops();
         d3.select(div).datum(data).call(chart);
 
-        expect(div.querySelectorAll('svg').length).toBe(1);
+        expect(div.querySelectorAll('svg.event-drops-chart').length).toBe(1);
+    });
+
+    it('should remove all previously created charts in current selection to prevent duplicates', () => {
+        const div = document.createElement('div');
+        const data = [{ name: 'foo', dates: [] }];
+
+        const chart = d3.chart.eventDrops();
+        d3.select(div).datum(data).call(chart);
+        d3.select(div).datum(data).call(chart);
+
+        expect(div.querySelectorAll('svg.event-drops-chart').length).toBe(1);
     });
 
     describe('start period', () => {
@@ -28,7 +39,7 @@ describe('d3.chart.eventDrops', () => {
         const data = [
             { name: 'foo', dates: [] },
             { name: 'bar', dates: [] },
-            { name: 'quz', dates: [] }
+            { name: 'quz', dates: [] },
         ];
 
         const chart = d3.chart.eventDrops().start(new Date('2010-01-25'));
@@ -42,7 +53,7 @@ describe('d3.chart.eventDrops', () => {
         const data = [
             { name: 'foo', dates: [new Date('2010-01-01')] },
             { name: 'bar', dates: [] },
-            { name: 'quz', dates: [new Date('2011-01-04'), new Date('2012-08-09')] }
+            { name: 'quz', dates: [new Date('2011-01-04'), new Date('2012-08-09')] },
         ];
 
         const chart = d3.chart.eventDrops().start(new Date('2010-01-25'));


### PR DESCRIPTION
If we want to change configuration after a first rendering, we have to call the `eventDropsChart` function again. However, before this PR, it appends a new chart instead of replacing existing ones.

Fixes #24.