### PR TITLE
[RFR] Use Firefox instead of PhantomJS for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ sudo: false
 language: node_js
 node_js:
   - "4.1"
+cache:
+  directories:
+    - node_modules
+branches:
+  only:
+    - master
 install:
   - npm install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.1"
+  - "0.10.32"
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10.36"
+  - "4.1"
 install:
   - npm install
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 script:
   - make test

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jsdom": "1.0.0-pre.6",
     "karma": "^0.13.19",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^0.2.3",
+    "karma-firefox-launcher": "0.1.7",
     "karma-webpack": "^1.7.0",
     "mocha": "1.21.4",
     "mocha-traceur": "2.1.0",

--- a/test/karma/bind.shim.js
+++ b/test/karma/bind.shim.js
@@ -1,7 +1,0 @@
-// PhantomJS doesn't support bind yet
-Function.prototype.bind = Function.prototype.bind || function (thisp) {
-    var fn = this;
-    return function () {
-        return fn.apply(thisp, arguments);
-    };
-};

--- a/test/karma/karma.conf.js
+++ b/test/karma/karma.conf.js
@@ -7,15 +7,15 @@ module.exports = function (config) {
 
     config.set({
         basePath: '../..',
+        browserNoActivityTimeout: 30000,
         frameworks: ['jasmine'],
-        browsers: ['PhantomJS'],
+        browsers: ['Firefox'],
         files: [
             './node_modules/d3/d3.js',
-            './test/karma/bind.shim.js',
             './test/karma/*',
             './test/karma/**/*.js'
         ],
-        plugins: ['karma-webpack', 'karma-jasmine', 'karma-phantomjs-launcher'],
+        plugins: ['karma-webpack', 'karma-jasmine', 'karma-firefox-launcher'],
         preprocessors: {
             'lib/**/*.js': 'webpack',
             'test/karma/**/*.js': 'webpack'


### PR DESCRIPTION
Indeed, PhantomJS has some lacks (for instance, we needed to polyfill the `bind` method) and mostly, it doesn't want to install on Travis anymore (that's why all tests on other PR fail).