### PR TITLE
Allow the draw function to be called programmatically

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,11 @@ function eventDrops(config = {}) {
                 );
 
             scales = getScales(dimensions, finalConfiguration, data);
-            const draw = drawer(svg, dimensions, scales, finalConfiguration);
-            draw(data);
+            this.draw = drawer(svg, dimensions, scales, finalConfiguration);
+            this.draw(data);
 
             if (finalConfiguration.zoomable) {
-                zoom(svg, dimensions, scales, finalConfiguration);
+                this.zoom = zoom(svg, dimensions, scales, finalConfiguration, data);
             }
         });
 

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -62,6 +62,16 @@ describe('eventDrops', () => {
         expect(div.querySelectorAll('.drop').length).toBe(3);
     });
 
+    it('should have a programmatic hooks', () => {
+        const div = document.createElement('div');
+        const data = [{ name: 'foo', data: [] }];
+
+        const chart = eventDrops({ zoomable: true });
+        d3.select(div).datum(data).call(chart);
+        expect(div.draw).toBeDefined();
+        expect(div.zoom).toBeDefined();
+    });
+
     it('should enable zoom only if `zoomable` configuration property is true', () => {
         const zoom = require('../../src/zoom');
         const data = [ { name: 'foo', data: [new Date()] }];


### PR DESCRIPTION
This PR allows a user of eventdrops to call the draw() function programmatically, the way the zoom handler does.  We wish to alter the zoom behavior slightly and need a hook to call draw() from the requestAnimationFrame() in a similar way.