### PR TITLE
[RFR] Remove pre and post publish hook in favor of make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ run: ## Run the webpack-dev-server
 build: ## Webpack build the project
 	./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe --progress --devtool source-map
 
+publish: build ## Publish current version of EventDrops
+	npm publish
+	$(MAKE) deploy-demo
+
 deploy-demo: build ## Deploy the demo at http://marmelab.com/EventDrops/
 	mkdir -p demo/dist/
 	cp ./dist/* demo/dist/

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "test": "test"
   },
   "scripts": {
-    "prepublish": "make build",
-    "postpublish": "make deploy-demo",
     "start": "webpack-dev-server --colors --devtool cheap-module-inline-source-map --host=0.0.0.0",
     "karma": "karma start test/karma/karma.conf.js",
     "test": "npm run karma -- --single-run",


### PR DESCRIPTION
Fixes #123.

`prepublish` ìs called at `npm install`, causing a slow installation and some issues for Windows users apparently, as discussed in #122. We now have a `make publish` command to be launched when a new version is ready. 

As we now have a `publish` target, I also moved the `postpublish` hook in it. 