### PR TITLE
Add support for typescript and common.js import syntax .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 npm-debug.log
+.idea/

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -99,7 +99,15 @@ const hideTooltip = () => {
         .style('opacity', 0);
 };
 
-const chart = eventDrops()
+const chart = eventDrops({
+        displayLabels: false,
+        margin: {
+            top: 60,
+            left: 10,
+            bottom: 40,
+            right: 50,
+        }
+    })
     .start(new Date(new Date().getTime() - 3600000 * 24 * 365)) // one year ago
     .end(new Date())
     .eventLineColor((d, i) => colors[i])

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5,6 +5,7 @@ import eventDrops from '../src';
 const md5 = require('./md5');
 const repositories = require('./data.json');
 
+
 const colors = d3.schemeCategory10;
 const gravatar = email =>
     `https://www.gravatar.com/avatar/${md5(email.trim().toLowerCase())}`;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3/build/d3';
 
-import eventDrops from '../src';
+import { eventDrops } from '../src';
 
 const md5 = require('./md5');
 const repositories = require('./data.json');

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -100,7 +100,7 @@ const hideTooltip = () => {
 };
 
 const chart = eventDrops({
-        displayLabels: false,
+        displayLabels: true,
         margin: {
             top: 60,
             left: 10,
@@ -108,8 +108,8 @@ const chart = eventDrops({
             right: 50,
         }
     })
-    .start(new Date(new Date().getTime() - 3600000 * 24 * 365)) // one year ago
-    .end(new Date())
+    .start(new Date(2015,0,1)) //new Date(new Date().getTime() - 3600000 * 24 * 365) one year ago
+    .end(new Date(2016,0,1))
     .eventLineColor((d, i) => colors[i])
     .date(d => new Date(d.date))
     .mouseover(showTooltip)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "files": [
     "dist/",
     "style.css",
-    "*.md"
+    "*.md",
+    "lib"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "event-drops",
   "version": "0.3.0-alpha1",
   "description": "A time based / event series interactive visualization using d3.js. Use drag and zoom to navigate in time.",
-  "main": "dist/eventDrops.js",
+  "main": "lib/eventDrops.js",
   "files": [
     "dist/",
     "style.css",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dist/",
     "style.css",
     "*.md",
-    "lib"
+    "lib",
+    "*.ts"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "event-drops",
   "version": "0.3.0-alpha1",
   "description": "A time based / event series interactive visualization using d3.js. Use drag and zoom to navigate in time.",
-  "main": "lib/eventDrops.js",
+  "main": "src/index.js",
   "files": [
     "dist/",
     "style.css",
     "*.md",
-    "lib",
+    "src",
     "*.ts"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "bugs": {
     "url": "https://github.com/marmelab/EventDrops/issues"
   },
+  "typings":"typings.d.ts",
   "homepage": "https://github.com/marmelab/EventDrops",
   "directories": {
     "example": "example",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "d3": "^4.7.0",
-    "debounce": "^1.0.0"
+    "debounce": "^1.0.0",
+    "configurable.js": "0.1.0"
   },
   "devDependencies": {
     "async": "^2.0.1",
@@ -23,6 +24,7 @@
     "babel-preset-es2015": "6.18.0",
     "babel-preset-stage-0": "6.16.0",
     "configurable.js": "0.1.0",
+    "copy-webpack-plugin": "^4.0.1",
     "css-loader": "0.25.0",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "14.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ const config = {
         bottom: 40,
         right: 50,
     },
+    displayLabels: true,
     labelsWidth: 210,
     labelsRightMargin: 10,
     locale: null,

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ const config = {
     mouseout: () => {},
     mouseover: () => {},
     zoomend: () => {},
+    zoomStreamCallback: () => {},
     click: () => {},
     dblclick: () => {},
     hasDelimiter: true,

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ const config = {
     mouseover: () => {},
     zoomend: () => {},
     click: () => {},
+    dblclick: () => {},
     hasDelimiter: true,
     date: d => d,
     hasTopAxis: true,

--- a/src/drawer/drops.js
+++ b/src/drawer/drops.js
@@ -26,6 +26,7 @@ export default (container, scales, configuration) =>
             .attr('cx', d => scales.x(configuration.date(d)))
             .attr('cy', configuration.lineHeight / 2)
             .attr('fill', configuration.eventColor)
+            .attr("data-id", d => d.id)
             .on('click', configuration.click)
             .on('dblclick',configuration.dblclick)
             .on('mouseover', configuration.mouseover)

--- a/src/drawer/drops.js
+++ b/src/drawer/drops.js
@@ -27,7 +27,7 @@ export default (container, scales, configuration) =>
             .attr('cy', configuration.lineHeight / 2)
             .attr('fill', configuration.eventColor)
             .attr("data-id", d => d.id)
-            .on('click', configuration.click)
+            .on('mousedown', configuration.click)
             .on('dblclick',configuration.dblclick)
             .on('mouseover', configuration.mouseover)
             .on('mouseout', configuration.mouseout);

--- a/src/drawer/drops.js
+++ b/src/drawer/drops.js
@@ -35,7 +35,7 @@ export default (container, scales, configuration) =>
         // unregister previous event handlers to prevent from memory leaks
         drops
             .exit()
-            .on('click', null)
+            .on('mousedown', null)
             .on('dblclick',null)
             .on('mouseout', null)
             .on('mouseover', null)

--- a/src/drawer/drops.js
+++ b/src/drawer/drops.js
@@ -27,6 +27,7 @@ export default (container, scales, configuration) =>
             .attr('cy', configuration.lineHeight / 2)
             .attr('fill', configuration.eventColor)
             .on('click', configuration.click)
+            .on('dblclick',configuration.dblclick)
             .on('mouseover', configuration.mouseover)
             .on('mouseout', configuration.mouseout);
 
@@ -34,6 +35,7 @@ export default (container, scales, configuration) =>
         drops
             .exit()
             .on('click', null)
+            .on('dblclick',null)
             .on('mouseout', null)
             .on('mouseover', null)
             .remove();

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -37,8 +37,8 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : configuration.margin.left)
-        )
+                (configuration.displayLabels ? (configuration.labelsWidth + configuration.labelsRightMargin) : (configuration.margin.left + configuration.margin.right))
+            )
         .attr(
             'transform',
             `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : configuration.margin.left}, ${configuration.margin.top})`

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -37,11 +37,11 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0)
+                (configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : configuration.margin.left)
         )
         .attr(
             'transform',
-            `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0}, 55)`
+            `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : configuration.margin.left}, ${configuration.margin.top})`
         );
 
     const dropsContainer = chartWrapper

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -37,11 +37,11 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.displayLabels ? (configuration.labelsWidth + configuration.labelsRightMargin) : (configuration.margin.left + configuration.margin.right))
+                (configuration.displayLabels ? (configuration.labelsWidth + configuration.labelsRightMargin) : 0)
             )
         .attr(
             'transform',
-            `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : configuration.margin.left}, ${configuration.margin.top})`
+            `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0}, ${configuration.margin.top})`
         );
 
     const dropsContainer = chartWrapper

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -16,7 +16,7 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.displayLabels && configuration.labelsWidth + configuration.labelsRightMargin)
+                (configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0)
         )
         .attr(
             'height',

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -70,7 +70,9 @@ export default (svg, dimensions, scales, configuration) => {
         configuration,
         dimensions
     );
+    
     const labels = labelsFactory(labelsContainer, scales, configuration);
+    
     const drops = dropsFactory(dropsContainer, scales, configuration);
 
     return data => {

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -16,7 +16,7 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.labelsWidth + configuration.labelsRightMargin)
+                (configuration.displayLabels && configuration.labelsWidth + configuration.labelsRightMargin)
         )
         .attr(
             'height',
@@ -37,11 +37,11 @@ export default (svg, dimensions, scales, configuration) => {
         .attr(
             'width',
             dimensions.width -
-                (configuration.labelsWidth + configuration.labelsRightMargin)
+                (configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0)
         )
         .attr(
             'transform',
-            `translate(${configuration.labelsWidth + configuration.labelsRightMargin}, 55)`
+            `translate(${configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0}, 55)`
         );
 
     const dropsContainer = chartWrapper
@@ -78,7 +78,7 @@ export default (svg, dimensions, scales, configuration) => {
         delimiters(
             svg,
             scales,
-            configuration.labelsWidth + configuration.labelsRightMargin,
+            onfiguration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0,
             configuration.dateFormat
         );
         drops(data);

--- a/src/drawer/index.js
+++ b/src/drawer/index.js
@@ -78,7 +78,7 @@ export default (svg, dimensions, scales, configuration) => {
         delimiters(
             svg,
             scales,
-            onfiguration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0,
+            configuration.displayLabels ? configuration.labelsWidth + configuration.labelsRightMargin : 0,
             configuration.dateFormat
         );
         drops(data);

--- a/src/drawer/labels.js
+++ b/src/drawer/labels.js
@@ -2,6 +2,9 @@ import filterData from '../filterData';
 
 export default (container, scales, config) =>
     data => {
+        if(!config.displayLabels) {
+            return;
+        }
         const labels = container.selectAll('.label').data(data);
 
         const text = d => {

--- a/src/drawer/labels.js
+++ b/src/drawer/labels.js
@@ -4,7 +4,15 @@ export default (container, scales, config) =>
     data => {
         const result = [];
         if(!config.displayLabels) {
-            return;
+            if(data && !data.length){
+                return;
+            }
+            data.forEach( d => {
+                const count = filterData(d.data, scales.x, config.date).length;
+                result.push({name: d.name,count: count});    
+            })
+            
+            return result;
         }
 
         let labels;

--- a/src/drawer/labels.js
+++ b/src/drawer/labels.js
@@ -2,13 +2,22 @@ import filterData from '../filterData';
 
 export default (container, scales, config) =>
     data => {
+        const result = [];
         if(!config.displayLabels) {
             return;
         }
-        const labels = container.selectAll('.label').data(data);
+
+        let labels;
+        if(data){
+            labels = container.selectAll('.label').data(data);
+        }
+        else {
+            labels = container.selectAll('.label');   
+        }
 
         const text = d => {
             const count = filterData(d.data, scales.x, config.date).length;
+            result.push({name: d.name,count: count});
             return d.name + (count > 0 ? ` (${count})` : '');
         };
 
@@ -27,4 +36,5 @@ export default (container, scales, config) =>
             .text(text);
 
         labels.exit().remove();
+        return result;
     };

--- a/src/drawer/lineSeparator.js
+++ b/src/drawer/lineSeparator.js
@@ -16,8 +16,8 @@ export default (scales, configuration, dimensions) =>
             .attr(
                 'x2',
                 dimensions.width -
-                    (configuration.labelsWidth +
-                        configuration.labelsRightMargin)
+                    (onfiguration.displayLabels ? configuration.labelsWidth +
+                        configuration.labelsRightMargin : 0)
             );
 
         separators.exit().remove();

--- a/src/drawer/lineSeparator.js
+++ b/src/drawer/lineSeparator.js
@@ -16,7 +16,7 @@ export default (scales, configuration, dimensions) =>
             .attr(
                 'x2',
                 dimensions.width -
-                    (onfiguration.displayLabels ? configuration.labelsWidth +
+                    (configuration.displayLabels ? configuration.labelsWidth +
                         configuration.labelsRightMargin : 0)
             );
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import drawer from './drawer';
 import zoom from './zoom';
 
 function eventDrops(config = {}) {
-    const finalConfiguration = Object.assing({}, defaultConfig, config );
+    const finalConfiguration = Object.assign({}, defaultConfig, config );
 
     const yScale = data => {
         return d3

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,7 @@ function eventDrops(config = {}) {
             d3.select(this).select('.event-drops-chart').remove();
 
             const dimensions = {
-                width: this.clientWidth -
-                    finalConfiguration.margin.left -
-                    finalConfiguration.margin.right,
+                width: this.clientWidth,
                 height: data.length * finalConfiguration.lineHeight,
             };
 
@@ -36,7 +34,12 @@ function eventDrops(config = {}) {
                 .select(this)
                 .append('svg')
                 .classed('event-drops-chart', true)
-                .attr('width', dimensions.width)
+                .attr(
+                    'width',
+                    dimensions.width +
+                        finalConfiguration.margin.left +
+                        finalConfiguration.margin.right
+                )
                 .attr(
                     'height',
                     dimensions.height +
@@ -59,8 +62,10 @@ function eventDrops(config = {}) {
         return {
             x: xScale(
                 dimensions.width -
-                    (configuration.labelsWidth +
-                        configuration.labelsRightMargin),
+                    (configuration.displayLabels
+                        ? configuration.labelsWidth +
+                              configuration.labelsRightMargin
+                        : 0),
                 [configuration.start, configuration.end]
             ),
             y: yScale(data),

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,14 @@ function eventDrops(config = {}) {
             draw(data);
 
             if (finalConfiguration.zoomable) {
-                zoom(svg, dimensions, scales, finalConfiguration, data);
+                zoom(
+                    svg,
+                    dimensions,
+                    scales,
+                    finalConfiguration,
+                    data,
+                    finalConfiguration.zoomStreamCallback
+                );
             }
         });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import drawer from './drawer';
 import zoom from './zoom';
 
 function eventDrops(config = {}) {
-    const finalConfiguration = { ...defaultConfig, ...config };
+    const finalConfiguration = Object.assing({}, defaultConfig, config );
 
     const yScale = data => {
         return d3

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import drawer from './drawer';
 import zoom from './zoom';
 
 function eventDrops(config = {}) {
-    const finalConfiguration = Object.assign({}, defaultConfig, config );
+    const finalConfiguration = Object.assign({}, defaultConfig, config);
 
     const yScale = data => {
         return d3
@@ -73,4 +73,4 @@ function eventDrops(config = {}) {
 d3.chart = d3.chart || {};
 d3.chart.eventDrops = eventDrops;
 
-export { eventDrops };
+export default eventDrops;

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,9 @@ function eventDrops(config = {}) {
             d3.select(this).select('.event-drops-chart').remove();
 
             const dimensions = {
-                width: this.clientWidth,
+                width: this.clientWidth -
+                    finalConfiguration.margin.left -
+                    finalConfiguration.margin.right,
                 height: data.length * finalConfiguration.lineHeight,
             };
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,4 +73,4 @@ function eventDrops(config = {}) {
 d3.chart = d3.chart || {};
 d3.chart.eventDrops = eventDrops;
 
-export default eventDrops;
+export { eventDrops };

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,8 @@ function eventDrops(config = {}) {
                 .attr(
                     'width',
                     dimensions.width +
-                        finalConfiguration.margin.left +
-                        finalConfiguration.margin.right
+                        (finalConfiguration.margin.left +
+                            finalConfiguration.margin.right)
                 )
                 .attr(
                     'height',

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -76,11 +76,17 @@ export default (
         });
     };
 
+    const zoomEnd = (data, index, element) => {
+        const scalingFunction = d3.event.transform.rescaleX(scales.x);
+        const domain = scalingFunction.domain();
+        configuration.zoomend({dates: {from: domain[0], to: domain[1]}});
+    };
+
     const zoom = d3
         .zoom()
         .scaleExtent([configuration.minScale, configuration.maxScale])
         .on('zoom', onZoom)
-        .on('end', configuration.zoomend);
+        .on('end', zoomEnd);
 
     container.call(zoom);
     return zoom;

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -30,11 +30,20 @@ export default (
 
         const sumDataCount = debounce(
             (data, callback) => {
-                const result = labels(
-                    container.select('.labels'),
-                    { x: scalingFunction },
-                    configuration
-                )(data);
+                const domain = scalingFunction.domain();
+
+                const result = {
+                    counts: labels(
+                        container.select('.labels'),
+                        { x: scalingFunction },
+                        configuration
+                    )(data),
+                    dates: {
+                        from: domain[0],
+                        to: domain[1]
+                    }
+                };
+
                 delimiters(
                     container,
                     { x: scalingFunction },

--- a/test/karma/drawer/drops.js
+++ b/test/karma/drawer/drops.js
@@ -1,5 +1,6 @@
 import eventDrops from '../../../src';
 
+
 describe('Drops drawer', () => {
     let wrapper;
     beforeEach(() => {

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -1,5 +1,6 @@
 import eventDrops from '../../src';
 
+
 describe('eventDrops', () => {
     it('should append a SVG element to given selection', () => {
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,4 @@
+declare namespace eventDrops{     
+	export function eventDrops(config:any):any;
+}
+export = eventDrops;


### PR DESCRIPTION
I want to be able to debug eventdrops inside my host app. 
so I made few changes 

1. To support type script.
2. To support import statement inside of webpack bundling with Common.js syntax 
3. To be able to debug the code inside the host 

this way I am able to debug and develop to eventdrops inside my host . 
with no need to deploy on every change.