### PR TITLE
[WIP] Date function from configuration is not called in zoom handler

### DIFF
--- a/lib/zoom.js
+++ b/lib/zoom.js
@@ -25,7 +25,7 @@ export default (container, dimensions, scales, configuration, data, callback) =>
                 const drops = container.selectAll('.drop-line')
                     .selectAll('.drop')
                     .attr('cx',(d,i) => {
-                        return scalingFunction(new Date(d.date))
+                        return scalingFunction(configuration.date(d))
                 })
 
                 sumDataCount(data);    

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -67,9 +67,10 @@ describe('eventDrops', () => {
         const zoom = require('../../lib/zoom');
         const data = [ { name: 'foo', data: [new Date()] }];
 
-        const test = (zoomable, expectedZoomableBehavior) => {
-            zoom.default = jasmine.createSpy();
+        spyOn(zoom, 'default').and.callThrough();
 
+        const test = (zoomable, expectedZoomableBehavior) => {
+            zoom.default.calls.reset();
             const div = document.createElement('div');
 
             const chart = eventDrops().zoomable(zoomable);


### PR DESCRIPTION
Zoom handler does not call date callback and tries to retrieve date value from `date` property.

Fixes #149.