### PR TITLE
[WIP] Set metaballs SVG filter to drops container only if configured

### DIFF
--- a/lib/drawer/index.js
+++ b/lib/drawer/index.js
@@ -37,8 +37,7 @@ export default (svg, dimensions, scales, configuration) => {
     const dropsContainer = chartContainer
         .append('g')
         .classed('drops-container', true)
-        .attr('clip-path', 'url(#drops-container-clipper)')
-        .style('filter', 'url(#metaballs)');
+        .attr('clip-path', 'url(#drops-container-clipper)');
 
     chartContainer
         .append('g')
@@ -48,6 +47,7 @@ export default (svg, dimensions, scales, configuration) => {
         .attr('transform', `translate(0, -35)`);
 
     if (configuration.metaballs) {
+        dropsContainer.style('filter', 'url(#metaballs)');
         metaballs(defs);
     }
 

--- a/test/karma/drawer/index.js
+++ b/test/karma/drawer/index.js
@@ -1,0 +1,58 @@
+import eventDrops from '../../../lib/eventDrops';
+import * as index from '../../../lib/drawer/index';
+
+describe('Main drawer', () => {
+
+    let dimensions;
+    let svg;
+    let scales;
+
+    beforeEach(() => {
+        dimensions = {
+            height: 100,
+            width: 200
+        };
+        scales = {
+            x: d3.scaleTime(),
+            y: d3.scaleOrdinal()
+        };
+        svg = d3.select('body').append('svg');
+    });
+
+    describe('Metaballs behavior', () => {
+
+        const invokeWithMetaballs = (value) => {
+            const configuration = {
+                margin: {
+                    top: 60,
+                    left: 200,
+                    bottom: 40,
+                    right: 50,
+                },
+                metaballs: value
+            };
+            index.default(svg, dimensions, scales, configuration);
+        };
+        let metaballs;
+
+        beforeEach(() => {
+            metaballs = require('../../../lib/metaballs');
+            spyOn(metaballs, 'metaballs').and.callThrough();
+        });
+
+        it('should use metaballs filter when configured', () => {
+            invokeWithMetaballs(true);
+            expect(metaballs.metaballs).toHaveBeenCalled();
+            expect(metaballs.metaballs).toHaveBeenCalledWith(svg.select('defs'));
+            expect(svg.select('.drops-container').style('filter')).toEqual('url("#metaballs")');
+        });
+
+        it('should not use metaballs filter when not configured', () => {
+            invokeWithMetaballs(false);
+            expect(metaballs.metaballs.calls.any()).toBe(false);
+            expect(svg.select('.drops-container').style('filter')).toEqual('none');
+        });
+
+    });
+
+});


### PR DESCRIPTION
Drops container has had metaballs filter set regardless of whether metaballs option was configured or not, resulting in link to non-existent definition when metaballs option was set to false.