### PR TITLE
[RFR] Fix D3 reference

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,3 @@
-import * as d3 from 'd3/build/d3';
-
 const config = {
     lineHeight: 40,
     start: new Date(0),

--- a/src/drawer/drops.js
+++ b/src/drawer/drops.js
@@ -1,10 +1,5 @@
-import * as d3 from 'd3/build/d3';
-
 export default (container, scales, configuration) =>
-    data => {
-        const leftOffset = configuration.labelsWidth +
-            configuration.labelsRightMargin;
-
+    (data) => {
         const dropLines = container
             .selectAll('.drop-line')
             .data(data)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import * as d3 from 'd3/build/d3';
 import configurable from 'configurable.js';
 
 import './style.css';

--- a/src/xAxis.js
+++ b/src/xAxis.js
@@ -1,5 +1,3 @@
-import * as d3 from 'd3/build/d3';
-
 export default (xScale, configuration, where) => {
     const tickFormat = configuration.locale
         ? configuration.locale.timeFormat

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -1,4 +1,3 @@
-import * as d3 from 'd3/build/d3';
 import xAxis from './xAxis';
 import labels from './drawer/labels';
 import { boolOrReturnValue } from './drawer/xAxis';

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -1,18 +1,19 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     entry: {
-        demo: ['./demo/demo.css', './demo/demo.js'],
+        demo: [
+            './demo/demo.css',
+            './demo/demo.js',
+        ],
     },
     output: {
         filename: '[name].js',
         path: path.resolve(__dirname, 'demo/dist'),
         library: 'eventDrops',
         libraryTarget: 'umd',
-    },
-    externals: {
-        d3: 'd3',
     },
     module: {
         rules: [
@@ -35,6 +36,9 @@ module.exports = {
         ],
     },
     plugins: [
+        new webpack.ProvidePlugin({
+            d3: 'd3',
+        }),
         new HtmlWebpackPlugin({
             template: path.join(__dirname, 'demo/index.html'),
         }),


### PR DESCRIPTION
Fixes #141.

Two different instances of D3 were provided: the one included in each file and the global one we modify and on which we add the `d3.chart.eventDrops` object. This PR keeps only the global one.