### PR TITLE
[RFR] Allow to retrieve displayed data time range

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ d3.select('#chart_placeholder')
   .call(eventDropsChart);
 ```
 
-## Configuration
+## API
+
+### Configuration
 
 EventDrops follows the [d3.js reusable charts pattern](http://bost.ocks.org/mike/chart/) to let you customize the chart at will:
 
@@ -114,9 +116,32 @@ Configurable values:
   - `zoomable`: *true* by default. Enable zoom-in/zoom-out and dragging handlers.
   - `date`: function that returns the date from each data point when passing objects. Defaults to `d=>d`.
 
-## Styling
+### Exposed Methods
 
-You can style all elements of the chart in CSS. Check the source to see the available selectors.
+EventDrops exposes some of its methods to ease your developer life:
+
+* **scales()**: retrieves both `{ x, y }` scales, especially useful for `visibleDataInRow` method.
+* **visibleDataInRow(data, scale)**: retrieves currently displayed data, filtered within current time range.
+
+## FAQ
+
+### How to get time range and displayed data on `zoomend` event?
+
+When moving across the timeline or (un)zooming it, a `zoomend` event is triggered. To retrieve access to
+current time range and its filtered data, use D3.js `rescale` function and EventDrops `visibleDataInRow` like
+the following:
+
+``` js
+chart.zoomend((data) => {
+    const currentScale = chart.scales.x;
+    const newScale = d3.event ? d3.event.transform.rescaleX(currentScale) : currentScale;
+    const filteredData = data.map(dataRow => chart.visibleDataInRow(dataRow.data, newScale));
+
+    // retrieve start and end dates
+    newScale.domain()[0].toLocaleDateString('en-US');
+    newScale.domain()[1].toLocaleDateString('en-US');
+});
+```
 
 ## Programmatic Zoom
 
@@ -131,7 +156,7 @@ var zoom = element[0][0].zoom;
 
 The example here shows how to manipulate it: http://bl.ocks.org/mbostock/7ec977c95910dd026812
 
-## Extending / Hacking
+## Contributing
 
 First, install the dependencies:
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Configurable values:
 
 ### Exposed Methods
 
-EventDrops exposes some of its methods to ease your developer life:
+EventDrops exposes some of its attributes and methods to ease your developer life:
 
-* **scales()**: retrieves both `{ x, y }` scales, especially useful for `visibleDataInRow` method.
+* **scales**: object containing both `{ x, y }` scales, especially useful for `visibleDataInRow` method,
 * **visibleDataInRow(data, scale)**: retrieves currently displayed data, filtered within current time range.
 
 ## FAQ

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -5,6 +5,7 @@
 
 body {
     font-size: 16px;
+    color: #222;
     background: #eee;
     padding: 0 3rem 1rem 3rem;
     font-family: 'Muli', 'sans serif';
@@ -26,6 +27,15 @@ h1 {
     font-weight: normal;
     font-size: 3rem;
     color: #aaa;
+}
+
+p {
+    line-height: 1.5;
+}
+
+.infos {
+    text-align: center;
+    margin-bottom: 1rem;
 }
 
 .drop {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,35 +2,10 @@ import * as d3 from 'd3/build/d3';
 
 import eventDrops from '../src';
 
-const md5 = require('./md5');
 const repositories = require('./data.json');
+const { gravatar, humanizeDate } = require('./utils');
 
 const colors = d3.schemeCategory10;
-const gravatar = email =>
-    `https://www.gravatar.com/avatar/${md5(email.trim().toLowerCase())}`;
-
-// September 4 1986 8:30 PM
-const humanizeDate = date => {
-    const monthNames = [
-        'Jan.',
-        'Feb.',
-        'March',
-        'Apr.',
-        'May',
-        'June',
-        'Jul.',
-        'Aug.',
-        'Sept.',
-        'Oct.',
-        'Nov.',
-        'Dec.',
-    ];
-
-    return `
-        ${monthNames[date.getMonth()]} ${date.getDate()} ${date.getFullYear()}
-        ${date.getHours()}:${date.getMinutes()}
-    `;
-};
 
 const FONT_SIZE = 16; // in pixels
 const TOOLTIP_WIDTH = 30; // in rem
@@ -62,7 +37,7 @@ const showTooltip = (commit) => {
     const ARROW_WIDTH = FONT_SIZE;
     const left = direction === 'right'
         ? d3.event.pageX - rightOrLeftLimit
-        : d3.event.pageX - ARROW_MARGIN * FONT_SIZE - ARROW_WIDTH / 2;
+        : d3.event.pageX - ((ARROW_MARGIN * (FONT_SIZE - ARROW_WIDTH)) / 2);
 
     tooltip.html(
         `
@@ -98,33 +73,37 @@ const hideTooltip = () => {
         .style('opacity', 0);
 };
 
-const numberCommits = document.getElementById('numberCommits');
-const zoomStart = document.getElementById('zoomStart');
-const zoomEnd = document.getElementById('zoomEnd');
+const numberCommits = global.document.getElementById('numberCommits');
+const zoomStart = global.document.getElementById('zoomStart');
+const zoomEnd = global.document.getElementById('zoomEnd');
 
-const getNumberCommits = (data) => {
-    const newScale = d3.event.transform.rescaleX(chart.scales.x);
-    const filteredData = chart.visibleData(data);
-    console.log(filteredData);
-    numberCommits.textContent = +filteredData.length;
+const renderStats = (data) => {
+    const newScale = d3.event ? d3.event.transform.rescaleX(chart.scales.x) : chart.scales.x;
+    const filteredCommits = data.reduce((total, repository) => {
+        const filteredRow = chart.visibleDataInRow(repository.data, newScale);
+        return total + filteredRow.length;
+    }, 0);
+
+    numberCommits.textContent = +filteredCommits;
     zoomStart.textContent = newScale.domain()[0].toLocaleDateString('en-US');
     zoomEnd.textContent = newScale.domain()[1].toLocaleDateString('en-US');
 };
 
 const chart = eventDrops()
-    .start(new Date(new Date().getTime() - 3600000 * 24 * 365)) // one year ago
+    .start(new Date(new Date().getTime() - (3600000 * 24 * 365))) // one year ago
     .end(new Date())
     .eventLineColor((d, i) => colors[i])
     .date(d => new Date(d.date))
     .mouseover(showTooltip)
     .mouseout(hideTooltip)
-    .zoomend(getNumberCommits);
+    .zoomend(renderStats);
 
-const element = d3.select('#eventdrops-demo').datum(
-    repositories.map(repository => ({
-        name: repository.name,
-        data: repository.commits,
-    }))
-);
+const repositoriesData = repositories.map(repository => ({
+    name: repository.name,
+    data: repository.commits,
+}));
 
+const element = d3.select('#eventdrops-demo').datum(repositoriesData);
 chart(element);
+
+renderStats(repositoriesData);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -36,7 +36,7 @@ const FONT_SIZE = 16; // in pixels
 const TOOLTIP_WIDTH = 30; // in rem
 
 // we're gonna create a tooltip per drop to prevent from transition issues
-const showTooltip = commit => {
+const showTooltip = (commit) => {
     d3.select('body').selectAll('.tooltip').remove();
 
     const tooltip = d3
@@ -98,13 +98,27 @@ const hideTooltip = () => {
         .style('opacity', 0);
 };
 
+const numberCommits = document.getElementById('numberCommits');
+const zoomStart = document.getElementById('zoomStart');
+const zoomEnd = document.getElementById('zoomEnd');
+
+const getNumberCommits = (data) => {
+    const newScale = d3.event.transform.rescaleX(chart.scales.x);
+    const filteredData = chart.visibleData(data);
+    console.log(filteredData);
+    numberCommits.textContent = +filteredData.length;
+    zoomStart.textContent = newScale.domain()[0].toLocaleDateString('en-US');
+    zoomEnd.textContent = newScale.domain()[1].toLocaleDateString('en-US');
+};
+
 const chart = eventDrops()
     .start(new Date(new Date().getTime() - 3600000 * 24 * 365)) // one year ago
     .end(new Date())
     .eventLineColor((d, i) => colors[i])
     .date(d => new Date(d.date))
     .mouseover(showTooltip)
-    .mouseout(hideTooltip);
+    .mouseout(hideTooltip)
+    .zoomend(getNumberCommits);
 
 const element = d3.select('#eventdrops-demo').datum(
     repositories.map(repository => ({

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -89,7 +89,7 @@ const renderStats = (data) => {
     zoomEnd.textContent = newScale.domain()[1].toLocaleDateString('en-US');
 };
 
-const chart = eventDrops()
+const createChart = eventDrops()
     .start(new Date(new Date().getTime() - (3600000 * 24 * 365))) // one year ago
     .end(new Date())
     .eventLineColor((d, i) => colors[i])
@@ -103,7 +103,6 @@ const repositoriesData = repositories.map(repository => ({
     data: repository.commits,
 }));
 
-const element = d3.select('#eventdrops-demo').datum(repositoriesData);
-chart(element);
+const chart = d3.select('#eventdrops-demo').datum(repositoriesData).call(createChart);
 
 renderStats(repositoriesData);

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,10 @@
     <body>
         <h1>Event Drops Demo</h1>
         <div id="eventdrops-demo" style="width: 90%;"></div>
+        <p class="infos">
+            You are currently previewing <span id="numberCommits">173</span> between <span id="zoomStart"></span>
+            and <span id="zoomEnd"></span>.
+        </p>
         <p>
             Released under MIT license, courtesy of <a href="http://marmelab.com/">marmelab</a>
             and <a href="https://github.com/canalplus">Canal Plus</a>. More details on our

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,13 +10,15 @@
         <h1>Event Drops Demo</h1>
         <div id="eventdrops-demo" style="width: 90%;"></div>
         <p class="infos">
-            You are currently previewing <span id="numberCommits">173</span> between <span id="zoomStart"></span>
+            <span id="numberCommits"></span> commits found between <span id="zoomStart"></span>
             and <span id="zoomEnd"></span>.
         </p>
-        <p>
-            Released under MIT license, courtesy of <a href="http://marmelab.com/">marmelab</a>
-            and <a href="https://github.com/canalplus">Canal Plus</a>. More details on our
-            <a href="https://github.com/marmelab/EventDrops">GitHub repository</a>.
-        </p>
+        <footer>
+            <p>
+                Released under MIT license, courtesy of <a href="http://marmelab.com/">marmelab</a>
+                and <a href="https://github.com/canalplus">Canal Plus</a>. More details on our
+                <a href="https://github.com/marmelab/EventDrops">GitHub repository</a>.
+            </p>
+        </footer>
     </body>
 </html>

--- a/demo/utils.js
+++ b/demo/utils.js
@@ -1,0 +1,26 @@
+const md5 = require('./md5');
+
+// Example display: September 4 1986 8:30 PM
+export const humanizeDate = (date) => {
+    const monthNames = [
+        'Jan.',
+        'Feb.',
+        'March',
+        'Apr.',
+        'May',
+        'June',
+        'Jul.',
+        'Aug.',
+        'Sept.',
+        'Oct.',
+        'Nov.',
+        'Dec.',
+    ];
+
+    return `
+        ${monthNames[date.getMonth()]} ${date.getDate()} ${date.getFullYear()}
+        ${date.getHours()}:${date.getMinutes()}
+    `;
+};
+
+export const gravatar = email => `https://www.gravatar.com/avatar/${md5(email.trim().toLowerCase())}`;

--- a/src/drawer/labels.js
+++ b/src/drawer/labels.js
@@ -1,10 +1,10 @@
 import filterData from '../filterData';
 
 export default (container, scales, config) =>
-    data => {
+    (data) => {
         const labels = container.selectAll('.label').data(data);
 
-        const text = d => {
+        const text = (d) => {
             const count = filterData(d.data, scales.x, config.date).length;
             return d.name + (count > 0 ? ` (${count})` : '');
         };

--- a/src/index.js
+++ b/src/index.js
@@ -63,14 +63,11 @@ function eventDrops(config = {}) {
             }
 
             eventDropGraph.scales = scales;
-            eventDropGraph.visibleData = () =>
-                filterData(
-                    data,
-                    eventDropGraph.scales.x,
-                    finalConfiguration.date
-                );
         });
     }
+
+    eventDropGraph.visibleDataInRow = (data, scale) =>
+        filterData(data, scale, finalConfiguration.date);
 
     configurable(eventDropGraph, finalConfiguration);
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,9 @@ function eventDrops(config = {}) {
     }
 
     function eventDropGraph(selection) {
-        return selection.each(function selector(data) {
+        let scales;
+
+        const chart = selection.each(function selector(data) {
             d3.select(this).select('.event-drops-chart').remove();
 
             const dimensions = {
@@ -54,20 +56,21 @@ function eventDrops(config = {}) {
                         finalConfiguration.margin.bottom
                 );
 
-            const scales = getScales(dimensions, finalConfiguration, data);
+            scales = getScales(dimensions, finalConfiguration, data);
             const draw = drawer(svg, dimensions, scales, finalConfiguration);
             draw(data);
 
             if (finalConfiguration.zoomable) {
                 zoom(svg, dimensions, scales, finalConfiguration);
             }
-
-            eventDropGraph.scales = scales;
         });
-    }
 
-    eventDropGraph.visibleDataInRow = (data, scale) =>
-        filterData(data, scale, finalConfiguration.date);
+        chart.scales = scales;
+        chart.visibleDataInRow = (data, scale) =>
+            filterData(data, scale, finalConfiguration.date);
+
+        return chart;
+    }
 
     configurable(eventDropGraph, finalConfiguration);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import configurable from 'configurable.js';
 
+import * as d3 from 'd3/build/d3';
+import filterData from './filterData';
+
 import './style.css';
 
 import defaultConfig from './config';
@@ -9,16 +12,26 @@ import zoom from './zoom';
 function eventDrops(config = {}) {
     const finalConfiguration = { ...defaultConfig, ...config };
 
-    const yScale = data => {
-        return d3
+    const yScale = data =>
+        d3
             .scaleOrdinal()
             .domain(data.map(d => d.name))
             .range(data.map((d, i) => i * finalConfiguration.lineHeight));
-    };
 
-    const xScale = (width, timeBounds) => {
-        return d3.scaleTime().domain(timeBounds).range([0, width]);
-    };
+    const xScale = (width, timeBounds) =>
+        d3.scaleTime().domain(timeBounds).range([0, width]);
+
+    function getScales(dimensions, configuration, data) {
+        return {
+            x: xScale(
+                dimensions.width -
+                    (configuration.labelsWidth +
+                        configuration.labelsRightMargin),
+                [configuration.start, configuration.end]
+            ),
+            y: yScale(data),
+        };
+    }
 
     function eventDropGraph(selection) {
         return selection.each(function selector(data) {
@@ -42,26 +55,21 @@ function eventDrops(config = {}) {
                 );
 
             const scales = getScales(dimensions, finalConfiguration, data);
-
             const draw = drawer(svg, dimensions, scales, finalConfiguration);
             draw(data);
 
             if (finalConfiguration.zoomable) {
-                zoom(svg, dimensions, scales, finalConfiguration, data);
+                zoom(svg, dimensions, scales, finalConfiguration);
             }
-        });
-    }
 
-    function getScales(dimensions, configuration, data) {
-        return {
-            x: xScale(
-                dimensions.width -
-                    (configuration.labelsWidth +
-                        configuration.labelsRightMargin),
-                [configuration.start, configuration.end]
-            ),
-            y: yScale(data),
-        };
+            eventDropGraph.scales = scales;
+            eventDropGraph.visibleData = () =>
+                filterData(
+                    data,
+                    eventDropGraph.scales.x,
+                    finalConfiguration.date
+                );
+        });
     }
 
     configurable(eventDropGraph, finalConfiguration);

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -1,17 +1,9 @@
-import xAxis from './xAxis';
+import debounce from 'debounce';
 import labels from './drawer/labels';
 import { boolOrReturnValue } from './drawer/xAxis';
-import debounce from 'debounce';
 
-export default (
-    container,
-    dimensions,
-    scales,
-    configuration,
-    data,
-    callback
-) => {
-    const onZoom = (data, index, element) => {
+export default (container, dimensions, scales, configuration, callback) => {
+    const onZoom = (data) => {
         const scalingFunction = d3.event.transform.rescaleX(scales.x);
 
         if (boolOrReturnValue(configuration.hasTopAxis, data)) {
@@ -35,13 +27,11 @@ export default (
             100
         );
 
-        requestAnimationFrame(() => {
-            const drops = container
+        global.requestAnimationFrame(() => {
+            container
                 .selectAll('.drop-line')
                 .selectAll('.drop')
-                .attr('cx', (d, i) => {
-                    return scalingFunction(new Date(d.date));
-                });
+                .attr('cx', d => scalingFunction(new Date(d.date)));
 
             sumDataCount(data);
 

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -129,4 +129,33 @@ describe('eventDrops', () => {
         expect(scales.x).not.toBe(null);
         expect(scales.y).not.toBe(null);
     });
+
+    it('should expose a "visibleDataInRow" function to get viewport visible data', () => {
+        const div = global.document.createElement('div');
+        const dataSet = [{
+            name: 'foo',
+            data: [
+                { date: new Date('2016-04-04') },
+                { date: new Date('2016-04-05') },
+                { date: new Date('2016-04-06') },
+                { date: new Date('2016-04-07') },
+                { date: new Date('2016-04-08') },
+            ],
+        }];
+
+        // display data between yesterday and tomorrow
+        const configuredEventDrops = eventDrops()
+            .start(new Date('2016-04-05'))
+            .end(new Date('2016-04-07'))
+            .date(d => d.date);
+
+        const chart = d3.select(div).datum(dataSet).call(configuredEventDrops);
+
+        const visibleDatas = chart.visibleDataInRow(dataSet[0].data, chart.scales.x);
+        expect(visibleDatas).toEqual([
+            { date: new Date('2016-04-05') },
+            { date: new Date('2016-04-06') },
+            { date: new Date('2016-04-07') },
+        ]);
+    });
 });

--- a/test/karma/eventDrops.js
+++ b/test/karma/eventDrops.js
@@ -2,7 +2,6 @@ import eventDrops from '../../src';
 
 describe('eventDrops', () => {
     it('should append a SVG element to given selection', () => {
-
         const div = document.createElement('div');
         const data = [{ name: 'foo', data: [] }];
 
@@ -111,5 +110,23 @@ describe('eventDrops', () => {
 
         d3.select(div).datum(data).call(chart);
         expect(div.querySelector('.chart-wrapper').attributes.transform.value).toBe('translate(60, 55)');
+    });
+
+    it('should expose its scales via scale property', () => {
+        const div = global.document.createElement('div');
+        const data = [
+            { name: 'foo', data: [{ date: new Date('2010-01-01'), foo: 'bar1' }] },
+        ];
+
+        const configuredEventDrops = eventDrops()
+            .start(new Date(new Date().getTime() - (3600000 * 24 * 365))) // one year ago
+            .end(new Date())
+            .date(d => new Date(d.date));
+
+        const chart = d3.select(div).datum(data).call(configuredEventDrops);
+        const scales = chart.scales;
+
+        expect(scales.x).not.toBe(null);
+        expect(scales.y).not.toBe(null);
     });
 });


### PR DESCRIPTION
This PR allows to retrieve start and end date of zoomed data (and not the overall boundaries). Moreover, it exports the filtering data function to retrieve only displayed data.

- [x] Retrieve currently displayed data time range
- [x] Allow to retrieve only filtered data
- [x] Update documentation
- [x] Add tests