### PR TITLE
[RFR] better metaballs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,14 @@
 export default {
     metaballs: {
-        blurDeviation: 5,
-        colorMatrix: '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 25 -7',
+        blurDeviation: 10,
+        colorMatrix: '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 50 -10',
     },
     bound: {
         format: d3.timeFormat('%d %B %Y'),
     },
     drop: {
         color: null,
-        radius: 8,
+        radius: 5,
     },
     label: {
         padding: 20,
@@ -17,7 +17,7 @@ export default {
     },
     line: {
         color: (_, index) => d3.schemeCategory10[index],
-        height: 40,
+        height: 80,
     },
     margin: {
         top: 20,

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,7 @@ export default {
     },
     line: {
         color: (_, index) => d3.schemeCategory10[index],
-        height: 80,
+        height: 40,
     },
     margin: {
         top: 20,

--- a/src/dropLine.js
+++ b/src/dropLine.js
@@ -54,10 +54,10 @@ export default (config, xScale) =>
             .call(drop(config, xScale));
 
         drops
-            .append('rect')
+            .append('rect') // The rect allow us to size the drops g element
             .attr('x', 0)
             .attr('y', -config.line.height / 2)
-            .attr('width', 1)
+            .attr('width', 1) // For the rect to impact its parent size it must have a non zero width
             .attr('height', config.line.height)
             .attr('fill', 'transparent');
 

--- a/src/dropLine.js
+++ b/src/dropLine.js
@@ -53,6 +53,14 @@ export default (config, xScale) =>
             )
             .call(drop(config, xScale));
 
+        drops
+            .append('rect')
+            .attr('x', 0)
+            .attr('y', -config.line.height / 2)
+            .attr('width', 1)
+            .attr('height', config.line.height)
+            .attr('fill', 'transparent');
+
         if (metaballs) {
             drops.style('filter', 'url(#metaballs)');
         }


### PR DESCRIPTION
add rect to properly size the g containing the metaballs, giving place to the filter to add the metaballs effect.

I did not move the filter on the viewport as it diluated lightly the color of the metaballs aura.
Also this way the metaball cannot grow larger than the line.