### PR TITLE
[RFR] allow to pass d3 as argument, rather than using a global instance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,5 @@
     "env": {
         "browser": true,
         "jasmine": true
-    },
-    "globals": {
-        "d3": true
     }
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5,8 +5,7 @@ import '../src/style.css';
 
 const repositories = require('./data.json');
 
-const chart = eventDrops();
-
+const chart = eventDrops({}, d3);
 const repositoriesData = repositories.map(repository => ({
     name: repository.name,
     data: repository.commits,

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5,7 +5,7 @@ import '../src/style.css';
 
 const repositories = require('./data.json');
 
-const chart = eventDrops({}, d3);
+const chart = eventDrops({ d3 });
 const repositoriesData = repositories.map(repository => ({
     name: repository.name,
     data: repository.commits,

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,6 +1,7 @@
 export default (config, xScale) =>
     selection => {
         const {
+            d3,
             label: {
                 width: labelWidth,
             },

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,7 +1,6 @@
-export default (config, xScale) =>
+export default (d3, config, xScale) =>
     selection => {
         const {
-            d3,
             label: {
                 width: labelWidth,
             },

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
-export default {
+export default (d3 = window.d3) => ({
+    d3,
     metaballs: {
         blurDeviation: 10,
         colorMatrix: '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 50 -10',
@@ -29,4 +30,4 @@ export default {
         start: new Date(new Date().getTime() - 3600000 * 24 * 365), // one year ago
         end: new Date(),
     },
-};
+});

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,4 @@
-export default (d3 = window.d3) => ({
-    d3,
+export default d3 => ({
     metaballs: {
         blurDeviation: 10,
         colorMatrix: '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 50 -10',

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export const draw = (d3, config, xScale) =>
             .call(axis(d3, config, xScale));
     };
 
-export default (customConfiguration = {}, d3 = window.d3) =>
+export default ({ config: customConfiguration = {}, d3 = window.d3 }) =>
     selection => {
         const config = defaultsDeep(
             customConfiguration,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import './style.css';
 export const withinRange = (date, dateBounds) =>
     new Date(date) >= dateBounds[0] && new Date(date) <= dateBounds[1];
 
-export const draw = (config, xScale) =>
+export const draw = (d3, config, xScale) =>
     selection => {
         const dateBounds = xScale.domain().map(d => new Date(d));
         const filteredData = selection.data().map(dataSet =>
@@ -31,17 +31,17 @@ export const draw = (config, xScale) =>
             .data(filteredData)
             .call(dropLine(config, xScale))
             .call(bounds(config, xScale))
-            .call(axis(config, xScale));
+            .call(axis(d3, config, xScale));
     };
 
-export default (customConfiguration = {}) =>
+export default (customConfiguration = {}, d3 = window.d3) =>
     selection => {
         const config = defaultsDeep(
             customConfiguration,
-            defaultConfiguration(customConfiguration.d3)
+            defaultConfiguration(d3)
         );
+
         const {
-            d3,
             metaballs,
             label: {
                 width: labelWidth,
@@ -55,6 +55,8 @@ export default (customConfiguration = {}) =>
             },
             margin,
         } = config;
+
+        const getEvent = () => d3.event; // keep d3.event mutable see https://github.com/d3/d3/issues/2733
 
         // Follow margins conventions (https://bl.ocks.org/mbostock/3019563)
         const width = selection.node().clientWidth - margin.left - margin.right;
@@ -73,7 +75,7 @@ export default (customConfiguration = {}) =>
             .append('svg')
             .attr('width', width)
             .classed('event-drop-chart', true)
-            .call(zoom(root, config, xScale, draw));
+            .call(zoom(d3, root, config, xScale, draw, getEvent));
 
         if (metaballs) {
             svg.call(addMetaballsDefs(config));
@@ -90,5 +92,5 @@ export default (customConfiguration = {}) =>
             .append('g')
             .classed('viewport', true)
             .attr('transform', `translate(${margin.left},${margin.top})`)
-            .call(draw(config, xScale));
+            .call(draw(d3, config, xScale));
     };

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,12 @@ export const draw = (config, xScale) =>
 
 export default (customConfiguration = {}) =>
     selection => {
-        const config = defaultsDeep(customConfiguration, defaultConfiguration);
-
+        const config = defaultsDeep(
+            customConfiguration,
+            defaultConfiguration(customConfiguration.d3)
+        );
         const {
+            d3,
             metaballs,
             label: {
                 width: labelWidth,

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -1,12 +1,10 @@
-export default (svg, config, xScale, draw) => {
-    console.log({ config });
-    const { d3 } = config;
+export default (d3, svg, config, xScale, draw, getEvent) => {
     const zoom = d3.zoom();
 
     zoom.on('zoom', () => {
-        const newScale = d3.event.transform.rescaleX(xScale);
+        const newScale = getEvent().transform.rescaleX(xScale);
         // @FIXME: remove d3.selectAll to use current selection
-        d3.selectAll('svg').call(draw(config, newScale));
+        d3.selectAll('svg').call(draw(d3, config, newScale));
     });
 
     return zoom;

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -1,4 +1,6 @@
 export default (svg, config, xScale, draw) => {
+    console.log({ config });
+    const { d3 } = config;
     const zoom = d3.zoom();
 
     zoom.on('zoom', () => {

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
 
 module.exports = {
     entry: {
@@ -36,9 +35,6 @@ module.exports = {
         ],
     },
     plugins: [
-        new webpack.ProvidePlugin({
-            d3: 'd3',
-        }),
         new HtmlWebpackPlugin({
             template: path.join(__dirname, 'demo/index.html'),
         }),


### PR DESCRIPTION
Allow to either use a global d3 (eg from a cdn) or an imported one from dependencies.