### PR TITLE
[RFR] Add missing mouse events

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -65,3 +65,64 @@ footer p {
     color: #888;
     font-size: .8rem;
 }
+
+.tooltip {
+    position: absolute;
+    background: #fff;
+    border: 3px solid #e7e7e7;
+    border-radius: 1rem;
+    padding: .5rem 1rem;
+    width: 30rem;
+    line-height: 1.4rem;
+}
+
+.tooltip::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: -.65rem;
+    width: 1rem;
+    height: 1rem;
+    background: #fff;
+    border: 3px solid #e7e7e7;
+    border-width: 3px 0 0 3px;
+    transform: rotate(45deg);
+    z-index: 1;
+}
+
+.tooltip.left::before {
+    left: 1.65rem;
+}
+
+.tooltip.right::before {
+    right: 1.65rem;
+}
+
+.tooltip .commit {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.tooltip .avatar {
+    width: 5rem;
+    height: 5rem;
+    border-radius: .5rem;
+    margin-right: 1rem;
+    flex: 0 0 5rem;
+}
+
+.tooltip .content {
+    flex: 1 0 0;
+}
+
+.tooltip h3 {
+    font-size: 1rem;
+}
+
+.tooltip p {
+    font-size: .9rem;
+    color: #777;
+}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3/build/d3';
 
 import eventDrops from '../src';
 import '../src/style.css';
-import { humanizeDate } from './utils';
+import { gravatar, humanizeDate } from './utils';
 
 const repositories = require('./data.json');
 
@@ -18,6 +18,10 @@ const updateCommitsInformation = (chart) => {
     zoomEnd.textContent = humanizeDate(chart.scale().domain()[1]);
 };
 
+const tooltip = d3.select('body').append('div')
+    .classed('tooltip', true)
+    .style('opacity', 0);
+
 const chart = eventDrops({
     d3,
     config: {
@@ -26,6 +30,34 @@ const chart = eventDrops({
         },
         zoom: {
             onZoomEnd: () => updateCommitsInformation(chart),
+        },
+        drop: {
+            onMouseOver: (commit) => {
+                tooltip.transition()
+                    .duration(200)
+                    .style('opacity', 1);
+
+                tooltip
+                    .html(`
+                        <div class="commit">
+                        <img class="avatar" src="${gravatar(commit.author.email)}" alt="${commit.author.name}" title="${commit.author.name}" />
+                        <div class="content">
+                            <h3 class="message">${commit.message}</h3>
+                            <p>
+                                <a href="https://www.github.com/${commit.author.name}" class="author">${commit.author.name}</a>
+                                on <span class="date">${humanizeDate(new Date(commit.date))}</span> -
+                                <a class="sha" href="${commit.sha}">${commit.sha.substr(0, 10)}</a>
+                            </p>
+                        </div>
+                    `)
+                    .style('left', `${d3.event.pageX - 30}px`)
+                    .style('top', `${d3.event.pageY + 20}px`);
+            },
+            onMouseOut: () => {
+                tooltip.transition()
+                    .duration(500)
+                    .style('opacity', 0);
+            },
         },
     },
 });

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,9 @@ export default d3 => ({
         color: null,
         radius: 5,
         date: d => new Date(d),
+        onClick: () => {},
+        onMouseOver: () => {},
+        onMouseOut: () => {},
     },
     label: {
         padding: 20,

--- a/src/drop.js
+++ b/src/drop.js
@@ -4,12 +4,15 @@ const filterOverlappingDrop = (xScale, dropDate) =>
     d => uniqBy(d.data, data => Math.round(xScale(dropDate(data))));
 
 export default (config, xScale) =>
-    selection => {
+    (selection) => {
         const {
             drop: {
                 color: dropColor,
                 radius: dropRadius,
                 date: dropDate,
+                onClick,
+                onMouseOver,
+                onMouseOut,
             },
         } = config;
 
@@ -23,8 +26,16 @@ export default (config, xScale) =>
             .classed('drop', true)
             .attr('r', dropRadius)
             .attr('fill', dropColor)
+            .on('click', onClick)
+            .on('mouseover', onMouseOver)
+            .on('mouseout', onMouseOut)
             .merge(drops)
             .attr('cx', d => xScale(dropDate(d)));
 
-        drops.exit().remove();
+        drops
+            .exit()
+            .on('click', null)
+            .on('mouseover', null)
+            .on('mouseout', null)
+            .remove();
     };

--- a/src/drop.spec.js
+++ b/src/drop.spec.js
@@ -159,6 +159,111 @@ describe('Drop', () => {
         expect(document.querySelectorAll('.drop').length).toBe(1);
     });
 
+    it('should call `onMouseOver` configuration listener when hovering a drop', () => {
+        const selection = d3.select('svg').data([
+            {
+                data: [{ date: now }],
+            },
+        ]);
+
+        const config = {
+            ...defaultConfig,
+            drop: {
+                ...defaultConfig.drop,
+                onMouseOver: jest.fn(),
+            },
+        };
+
+        drop(config, defaultScale)(selection);
+
+        const dropElement = d3.select('.drop').node();
+        const event = new MouseEvent('SVGEvents', {});
+        event.initMouseEvent(
+            'mouseover',
+            true,
+            true,
+            global,
+            0,
+            10,
+            10,
+            10,
+            10,
+            false,
+            false,
+            false,
+            false,
+            null,
+            dropElement
+        );
+        dropElement.dispatchEvent(event);
+
+        expect(config.drop.onMouseOver).toHaveBeenCalled();
+    });
+
+    it('should call `onMouseOut` configuration listener when blurring a drop', () => {
+        const selection = d3.select('svg').data([
+            {
+                data: [{ date: now }],
+            },
+        ]);
+
+        const config = {
+            ...defaultConfig,
+            drop: {
+                ...defaultConfig.drop,
+                onMouseOut: jest.fn(),
+            },
+        };
+
+        drop(config, defaultScale)(selection);
+
+        const dropElement = d3.select('.drop').node();
+        const event = new MouseEvent('SVGEvents', {});
+        event.initMouseEvent(
+            'mouseout',
+            true,
+            true,
+            global,
+            0,
+            10,
+            10,
+            10,
+            10,
+            false,
+            false,
+            false,
+            false,
+            null,
+            dropElement
+        );
+        dropElement.dispatchEvent(event);
+
+        expect(config.drop.onMouseOut).toHaveBeenCalled();
+    });
+
+    it('should call `onClick` configuration listener when clicking on drop', () => {
+        const selection = d3.select('svg').data([
+            {
+                data: [{ date: now }],
+            },
+        ]);
+
+        const config = {
+            ...defaultConfig,
+            drop: {
+                ...defaultConfig.drop,
+                onClick: jest.fn(),
+            },
+        };
+
+        drop(config, defaultScale)(selection);
+
+        const dropElement = d3.select('.drop').node();
+        dropElement.click();
+
+        expect(config.drop.onClick).toHaveBeenCalled();
+    });
+
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,11 @@ export default ({ config: customConfiguration = {}, d3 = window.d3 }) => {
 
         const {
             zoom: zoomConfig,
+            drop: {
+                onClick,
+                onMouseOut,
+                onMouseOver,
+            },
             metaballs,
             label: {
                 width: labelWidth,


### PR DESCRIPTION
Beginning of the following GIF is buggy. It seems my screencast recording screen interfered somehow in window events. Reloading it fixed the issue. Don't stop on the first seconds. ;)

![mouse](https://user-images.githubusercontent.com/688373/34167507-3ed5c1c4-e4e2-11e7-8128-00a65b5be6a2.gif)

An optimization would be to attach a single event listener to the SVG element and to use event delegation. Yet, let's postpone it for later in order to release the 4.0 version soon.