### PR TITLE
[RFR] Allow to tune tick formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "d3": "~4.7.0"
   },
   "dependencies": {
+    "d3-time-format": "^2.1.1",
     "debounce": "1.0.0",
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.uniqby": "^4.7.0"

--- a/src/axis.js
+++ b/src/axis.js
@@ -32,24 +32,28 @@ export const tickFormat = (date, formats, d3) => {
     return d3.timeFormat(formats.year)(date);
 };
 
-export default (d3, config, xScale) => selection => {
-    const { label: { width: labelWidth }, axis: { formats } } = config;
+export default (d3, config, xScale) => {
+    const { label: { width: labelWidth }, axis: { formats }, locale } = config;
 
-    const axis = selection.selectAll('.axis').data(d => d);
+    d3.timeFormatDefaultLocale(locale);
 
-    axis.exit().remove();
+    return selection => {
+        const axis = selection.selectAll('.axis').data(d => d);
 
-    const axisTop = d3
-        .axisTop(xScale)
-        .tickFormat(d => tickFormat(d, formats, d3));
+        axis.exit().remove();
 
-    axis
-        .enter()
-        .filter((_, i) => !i)
-        .append('g')
-        .classed('axis', true)
-        .attr('transform', `translate(${labelWidth},0)`)
-        .call(axisTop);
+        const axisTop = d3
+            .axisTop(xScale)
+            .tickFormat(d => tickFormat(d, formats, d3));
 
-    axis.call(axisTop);
+        axis
+            .enter()
+            .filter((_, i) => !i)
+            .append('g')
+            .classed('axis', true)
+            .attr('transform', `translate(${labelWidth},0)`)
+            .call(axisTop);
+
+        axis.call(axisTop);
+    };
 };

--- a/src/axis.js
+++ b/src/axis.js
@@ -34,9 +34,7 @@ export const tickFormat = (date, formats, d3) => {
 
 export default (d3, config, xScale) => {
     const { label: { width: labelWidth }, axis: { formats }, locale } = config;
-
     d3.timeFormatDefaultLocale(locale);
-
     return selection => {
         const axis = selection.selectAll('.axis').data(d => d);
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,9 +1,47 @@
+import { timeFormat } from 'd3-time-format';
+
+export const tickFormat = (date, formats, d3) => {
+    if (d3.timeSecond(date) < date) {
+        return d3.timeFormat(formats.milliseconds)(date);
+    }
+
+    if (d3.timeMinute(date) < date) {
+        return d3.timeFormat(formats.seconds)(date);
+    }
+
+    if (d3.timeHour(date) < date) {
+        return d3.timeFormat(formats.minutes)(date);
+    }
+
+    if (d3.timeDay(date) < date) {
+        return d3.timeFormat(formats.hours)(date);
+    }
+
+    if (d3.timeMonth(date) < date) {
+        if (d3.timeWeek(date) < date) {
+            return d3.timeFormat(formats.days)(date);
+        }
+
+        return d3.timeFormat(formats.weeks)(date);
+    }
+
+    if (d3.timeYear(date) < date) {
+        return d3.timeFormat(formats.months)(date);
+    }
+
+    return d3.timeFormat(formats.year)(date);
+};
+
 export default (d3, config, xScale) => selection => {
-    const { label: { width: labelWidth } } = config;
+    const { label: { width: labelWidth }, axis: { formats } } = config;
 
     const axis = selection.selectAll('.axis').data(d => d);
 
     axis.exit().remove();
+
+    const axisTop = d3
+        .axisTop(xScale)
+        .tickFormat(d => tickFormat(d, formats, d3));
 
     axis
         .enter()
@@ -11,7 +49,7 @@ export default (d3, config, xScale) => selection => {
         .append('g')
         .classed('axis', true)
         .attr('transform', `translate(${labelWidth},0)`)
-        .call(d3.axisTop(xScale));
+        .call(axisTop);
 
-    axis.call(d3.axisTop(xScale));
+    axis.call(axisTop);
 };

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -1,12 +1,46 @@
-import axis from './axis';
+import defaultLocale from 'd3-time-format/locale/en-US.json';
+
+import axis, { tickFormat } from './axis';
 
 const defaultConfig = {
     label: {
         width: 200,
     },
+    locale: defaultLocale,
+    axis: {
+        formats: {
+            milliseconds: '.%L',
+            seconds: ':%S',
+            minutes: '%I:%M',
+            hours: '%I %p',
+            days: '%a %d',
+            weeks: '%b %d',
+            months: '%B',
+            year: '%Y',
+        },
+    },
 };
 
 const defaultScale = d3.scaleTime();
+
+describe('Axis Tick Format', () => {
+    it('should format date correctly depending of current granularity', () => {
+        const formats = defaultConfig.axis.formats;
+        const test = (date, expectedOutput) => {
+            expect(tickFormat(new Date(date), formats, d3)).toBe(
+                expectedOutput
+            );
+        };
+
+        test(new Date('2017-05-04 11:20:38.217'), '.217');
+        test(new Date('2017-05-04 11:20:38.000'), ':38');
+        test(new Date('2017-05-04 11:20:00.000'), '11:20');
+        test(new Date('2017-05-04 11:00:00.000'), '11 AM');
+        test(new Date('2017-05-04 00:00:00.000'), 'Thu 04');
+        test(new Date('2017-05-01 00:00:00.000'), 'May');
+        test(new Date('2017-01-01 00:00:00.000'), '2017');
+    });
+});
 
 describe('Axis', () => {
     beforeEach(() => {
@@ -44,6 +78,20 @@ describe('Axis', () => {
         expect(axisTopSpy).toHaveBeenCalledWith(defaultScale);
     });
 
+    it('should use tick formats passed in configuration', () => {
+        const tickFormatSpy = jest.fn(() => () => {});
+        jest.spyOn(d3, 'axisTop').mockImplementation(() => ({
+            tickFormat: tickFormatSpy,
+        }));
+
+        const data = [[{ id: 'foo' }]];
+        const selection = d3.select('svg').data(data);
+        axis(d3, defaultConfig, defaultScale)(selection);
+
+        const tickFormat = tickFormatSpy.mock.calls[0][0];
+        expect(tickFormat(new Date('2017-01-01 12:00:00'))).toBe('12 PM');
+    });
+
     it('should remove "axis" group when data is removed', () => {
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
@@ -52,6 +100,24 @@ describe('Axis', () => {
         selection.data([[]]);
         axis(d3, defaultConfig, defaultScale)(selection);
         expect(document.querySelectorAll('.axis').length).toBe(0);
+    });
+
+    it('should display axis using configuration locale', () => {
+        const timeFormatDefaultLocaleSpy = jest.spyOn(
+            d3,
+            'timeFormatDefaultLocale'
+        );
+
+        const config = {
+            ...defaultConfig,
+            locale: defaultLocale,
+        };
+
+        const data = [[{ id: 'foo' }]];
+        const selection = d3.select('svg').data(data);
+        axis(d3, config, defaultScale)(selection);
+
+        expect(timeFormatDefaultLocaleSpy).toHaveBeenCalledWith(defaultLocale);
     });
 
     afterEach(() => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,7 @@
+import enLocale from 'd3-time-format/locale/en-US.json';
+
 export default d3 => ({
+    locale: enLocale,
     metaballs: {
         blurDeviation: 10,
         colorMatrix: '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 50 -10',
@@ -8,7 +11,7 @@ export default d3 => ({
     },
     axis: {
         formats: {
-            milliseconds: '.%L',
+            milliseconds: '%L',
             seconds: ':%S',
             minutes: '%I:%M',
             hours: '%I %p',

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,18 @@ export default d3 => ({
     bound: {
         format: d3.timeFormat('%d %B %Y'),
     },
+    axis: {
+        formats: {
+            milliseconds: '.%L',
+            seconds: ':%S',
+            minutes: '%I:%M',
+            hours: '%I %p',
+            days: '%a %d',
+            weeks: '%b %d',
+            months: '%B',
+            year: '%Y',
+        },
+    },
     drop: {
         color: null,
         radius: 5,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,12 @@ d3-time-format@2, d3-time-format@2.0.5:
   dependencies:
     d3-time "1"
 
+d3-time-format@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
+  dependencies:
+    d3-time "1"
+
 d3-time@1, d3-time@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.6.tgz#a55b13d7d15d3a160ae91708232e0835f1d5e945"


### PR DESCRIPTION
I tried to simplify at maximum configuration. Hence, now configuration looks like:

``` js
{
    locale: require('date-time-format/locale/fr-FR.json'),
    axis: {
        formats: {
            milliseconds: '%L',
            seconds: ':%S',
            minutes: '%I:%M',
            hours: '%I %p',
            days: '%a %d',
            weeks: '%b %d',
            months: '%B',
            year: '%Y',
        },
    },
}
```