### PR TITLE
Select the created SVG element, not all SVG elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             .classed('event-drop-chart', true);
 
         if (zoomConfig) {
-            svg.call(zoom(d3, root, config, xScale, draw, getEvent));
+            svg.call(zoom(d3, svg, config, xScale, draw, getEvent));
         }
 
         if (metaballs) {

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -35,8 +35,7 @@ export default (d3, svg, config, xScale, draw, getEvent) => {
 
         const newScale = transform.rescaleX(xScale);
 
-        // @TODO: fix me: use `svg` parameter instead of doing a new selection
-        d3.select('svg').call(draw(config, newScale));
+        svg.call(draw(config, newScale));
 
         if (onZoom) {
             onZoom(args);


### PR DESCRIPTION
Now selects the correct SVG element, instead of blindly selecting all SVG elements.

This addresses the TODO left behind, which meant the component did not play well when there are other SVG elements on the page.