### PR TITLE
[RFR] Use configuration date getter in data filtering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { addMetaballsDefs } from './metaballs';
 import './style.css';
 
 const withinRange = (date, dateBounds) =>
+    // @TODO: remove the `new Date()` constructor in the next major version: we need to force it at configuration level.
     new Date(date) >= dateBounds[0] && new Date(date) <= dateBounds[1];
 
 export default ({ d3 = window.d3, ...customConfiguration }) => {
@@ -77,6 +78,8 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
     chart.filteredData = () => chart._filteredData;
 
     const draw = (config, scale) => selection => {
+        const { drop: { date: dropDate } } = config;
+
         const dateBounds = scale.domain().map(d => new Date(d));
         const filteredData = selection.data().map(dataSet =>
             dataSet.map(row => {
@@ -85,7 +88,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
                 }
 
                 row.data = row.fullData.filter(d =>
-                    withinRange(d.date, dateBounds)
+                    withinRange(dropDate(d), dateBounds)
                 );
 
                 return row;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -59,34 +59,69 @@ describe('EventDrops', () => {
         ]);
     });
 
-    it('should give an access to currently filtered data', () => {
-        const chart = EventDrops({
-            range: {
-                start: new Date('2010-01-01'),
-                end: new Date('2011-01-01'),
-            },
+    describe('Data Filtering', () => {
+        it('should give an access to currently filtered data', () => {
+            const chart = EventDrops({
+                range: {
+                    start: new Date('2010-01-01'),
+                    end: new Date('2011-01-01'),
+                },
+            });
+
+            const root = d3.select('div').data([
+                [
+                    {
+                        data: [
+                            new Date('2009-01-01'),
+                            new Date('2010-01-01'),
+                            new Date('2011-01-01'),
+                            new Date('2012-01-01'),
+                        ],
+                    },
+                ],
+            ]);
+
+            root.call(chart);
+
+            const { data } = chart.filteredData()[0];
+            expect(data).toEqual([
+                new Date('2010-01-01'),
+                new Date('2011-01-01'),
+            ]);
         });
 
-        const root = d3.select('div').data([
-            [
-                {
-                    data: [
-                        { date: new Date('2009-01-01') },
-                        { date: new Date('2010-01-01') },
-                        { date: new Date('2011-01-01') },
-                        { date: new Date('2012-01-01') },
-                    ],
+        it('should filter data based on date retrieved using the `drop.date` configuration getter', () => {
+            const chart = EventDrops({
+                range: {
+                    start: new Date('2010-01-01'),
+                    end: new Date('2011-01-01'),
                 },
-            ],
-        ]);
+                drop: {
+                    date: d => d.createdAt,
+                },
+            });
 
-        root.call(chart);
+            const root = d3.select('div').data([
+                [
+                    {
+                        data: [
+                            { createdAt: new Date('2009-01-01') },
+                            { createdAt: new Date('2010-01-01') },
+                            { createdAt: new Date('2011-01-01') },
+                            { createdAt: new Date('2012-01-01') },
+                        ],
+                    },
+                ],
+            ]);
 
-        const { data } = chart.filteredData()[0];
-        expect(data).toEqual([
-            { date: new Date('2010-01-01') },
-            { date: new Date('2011-01-01') },
-        ]);
+            root.call(chart);
+
+            const { data } = chart.filteredData()[0];
+            expect(data).toEqual([
+                { createdAt: new Date('2010-01-01') },
+                { createdAt: new Date('2011-01-01') },
+            ]);
+        });
     });
 
     it('should update exposed scale at each draw', () => {


### PR DESCRIPTION
Closes #227.

Use configuration date getter instead of an hard-written `.date`.