### PR TITLE
[RFR] Responsive chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can either use D3 as a specific import (specifying it in first argument of `
 
 **[Configuration Reference](./docs/configuration.md)**
 
-In addition to this configuration object, it also exposes some public methods allowing you to customize your application based on filtered data:
+In addition to this configuration object, it also exposes some public members allowing you to customize your application based on filtered data:
 
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In addition to this configuration object, it also exposes some public members al
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
-*   **destroy** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
+*   **destroy()** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 *   **currentBreakpointLabel** returns current breakpoint (for instance `small`) among a [list of breakpoints](./docs/configuration.md#breakpoints).
 
 Hence, if you want to display number of displayed data and time bounds as in the [demo](https://marmelab.com/EventDrops/), you can use the following code:

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ You can either use D3 as a specific import (specifying it in first argument of `
 
 In addition to this configuration object, it also exposes some public methods allowing you to customize your application based on filtered data:
 
-* **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
-* **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
-* **draw(config, scale)** redraw chart using given configuration and `d3.scaleTime` scale
+*   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
+*   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
+*   **draw(config, scale)** redraw chart using given configuration and `d3.scaleTime` scale
+*   **destroy** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 
 Hence, if you want to display number of displayed data and time bounds as in the [demo](https://marmelab.com/EventDrops/), you can use the following code:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In addition to this configuration object, it also exposes some public members al
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
 *   **destroy** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
-*   **currentBreakpointLabel** returns a label of current breakpoint, [list of breakpoints](./docs/configuration.md#breakpoints).
+*   **currentBreakpointLabel** returns current breakpoint (for instance `small`) among a [list of breakpoints](./docs/configuration.md#breakpoints).
 
 Hence, if you want to display number of displayed data and time bounds as in the [demo](https://marmelab.com/EventDrops/), you can use the following code:
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In addition to this configuration object, it also exposes some public methods al
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
 *   **destroy** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
+*   **currentBreakpointLabel** returns a label of current breakpoint, [list of breakpoints](./docs/configuration.md#breakpoints).
 
 Hence, if you want to display number of displayed data and time bounds as in the [demo](https://marmelab.com/EventDrops/), you can use the following code:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In addition to this configuration object, it also exposes some public methods al
 
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
-*   **draw(config, scale)** redraw chart using given configuration and `d3.scaleTime` scale
+*   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
 *   **destroy** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 
 Hence, if you want to display number of displayed data and time bounds as in the [demo](https://marmelab.com/EventDrops/), you can use the following code:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,3 +332,20 @@ This parameter configures the maximum zoom level available. Set it to a lower va
 _Default: () => {}_
 
 Function to be executed when you want to destroy the chart. By default, it remove `resize` event and execute the callback.
+
+### numberDisplayedTicks
+
+\_Default:
+
+```js
+const chart = eventDrops({
+   numberDisplayedTicks: {
+        small: 3,
+        medium: 5,
+        large: 7,
+        extra: 12,
+    },
+});
+
+This parameter configures the number of ticks display in the header
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,11 +344,19 @@ const chart = eventDrops({
 
 When reducing chart width, we need to display less labels on the horizontal axis to keep a readable chart. This parameter aims to solve the issue. Hence, on smallest devices, it displays only 3 labels by default at the same time.
 
-Responsive breakpoints:
+### breakpoints
 
+\_Default:
+
+```js
+const chart = eventDrops({
+    breakpoints: {
+        small: 576,
+        medium: 768,
+        large: 992,
+        extra: 1200,
+    },
+});
 ```
-small: 576px
-medium: 768px
-large: 992px
-extra: 1200px
-```
+
+When reducing chart width, we need to display less labels on the horizontal axis to keep a readable chart. This parameter aims to solve the issue. Hence, we can define breakpoints in pixels.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,13 +333,22 @@ This parameter configures the maximum zoom level available. Set it to a lower va
 
 ```js
 const chart = eventDrops({
-   numberDisplayedTicks: {
+    numberDisplayedTicks: {
         small: 3,
         medium: 5,
         large: 7,
         extra: 12,
     },
 });
+```
 
-This parameter configures the number of ticks display in the header
+When reducing chart width, we need to display less labels on the horizontal axis to keep a readable chart. This parameter aims to solve the issue. Hence, on smallest devices, it displays only 3 labels by default at the same time.
+
+Responsive breakpoints:
+
+```
+small: 576px
+medium: 768px
+large: 992px
+extra: 1200px
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,12 +327,6 @@ _Default: Infinity_
 
 This parameter configures the maximum zoom level available. Set it to a lower value to prevent your users from zooming in too deeply.
 
-### destroy
-
-_Default: () => {}_
-
-Function to be executed when you want to destroy the chart. By default, it remove `resize` event and execute the callback.
-
 ### numberDisplayedTicks
 
 \_Default:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,8 +327,8 @@ _Default: Infinity_
 
 This parameter configures the maximum zoom level available. Set it to a lower value to prevent your users from zooming in too deeply.
 
-### removeOnResize
+### destroy
 
 _Default: () => {}_
 
-Function to be executed when you want to remove [`resize`](https://developer.mozilla.org/en-US/docs/Web/Events/resize) event.
+Function to be executed when you want to destroy the chart. By default, it remove `resize` event and execute the callback.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,3 +326,9 @@ This parameter configures the minimum zoom level available. Set it to a not-null
 _Default: Infinity_
 
 This parameter configures the maximum zoom level available. Set it to a lower value to prevent your users from zooming in too deeply.
+
+### removeOnResize
+
+_Default: () => {}_
+
+Function to be executed when you want to remove [`resize`](https://developer.mozilla.org/en-US/docs/Web/Events/resize) event.

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,4 +1,14 @@
 import { timeFormat } from 'd3-time-format';
+import breakpoints from './breakpoints';
+
+export const getBreakpointLabel = point =>
+    Object.keys(breakpoints).reduce((accumulator, label) => {
+        if (!accumulator.length && point <= breakpoints[label]) {
+            return label;
+        }
+
+        return accumulator;
+    }, '');
 
 export const tickFormat = (date, formats, d3) => {
     if (d3.timeSecond(date) < date) {
@@ -33,7 +43,12 @@ export const tickFormat = (date, formats, d3) => {
 };
 
 export default (d3, config, xScale) => {
-    const { label: { width: labelWidth }, axis: { formats }, locale } = config;
+    const {
+        label: { width: labelWidth },
+        axis: { formats },
+        locale,
+        numberDisplayedTicks,
+    } = config;
     d3.timeFormatDefaultLocale(locale);
     return selection => {
         const axis = selection.selectAll('.axis').data(d => d);
@@ -43,6 +58,9 @@ export default (d3, config, xScale) => {
         const axisTop = d3
             .axisTop(xScale)
             .tickFormat(d => tickFormat(d, formats, d3));
+
+        const breakpoint = getBreakpointLabel(window.innerWidth) || 'extra';
+        axisTop.ticks(numberDisplayedTicks[breakpoint]);
 
         axis
             .enter()

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,7 +1,6 @@
 import { timeFormat } from 'd3-time-format';
-import breakpoints from './breakpoints';
 
-export const getBreakpointLabel = point => {
+export const getBreakpointLabel = (breakpoints, point) => {
     for (const label in breakpoints) {
         if (point <= breakpoints[label]) {
             return label;
@@ -49,11 +48,12 @@ export default (d3, config, xScale) => {
         axis: { formats },
         locale,
         numberDisplayedTicks,
+        breakpoints,
     } = config;
     d3.timeFormatDefaultLocale(locale);
     return selection => {
         const axis = selection.selectAll('.axis').data(d => d);
-        const breakpoint = getBreakpointLabel(window.innerWidth);
+        const breakpoint = getBreakpointLabel(breakpoints, window.innerWidth);
 
         axis.exit().remove();
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,15 +1,5 @@
 import { timeFormat } from 'd3-time-format';
 
-export const getBreakpointLabel = (breakpoints, point) => {
-    for (const label in breakpoints) {
-        if (point <= breakpoints[label]) {
-            return label;
-        }
-    }
-
-    return 'extra';
-};
-
 export const tickFormat = (date, formats, d3) => {
     if (d3.timeSecond(date) < date) {
         return d3.timeFormat(formats.milliseconds)(date);
@@ -42,7 +32,7 @@ export const tickFormat = (date, formats, d3) => {
     return d3.timeFormat(formats.year)(date);
 };
 
-export default (d3, config, xScale, breakpoint) => {
+export default (d3, config, xScale, breakpointLabel) => {
     const {
         label: { width: labelWidth },
         axis: { formats },
@@ -58,7 +48,7 @@ export default (d3, config, xScale, breakpoint) => {
         const axisTop = d3
             .axisTop(xScale)
             .tickFormat(d => tickFormat(d, formats, d3))
-            .ticks(numberDisplayedTicks[breakpoint]);
+            .ticks(numberDisplayedTicks[breakpointLabel]);
 
         axis
             .enter()

--- a/src/axis.js
+++ b/src/axis.js
@@ -42,18 +42,16 @@ export const tickFormat = (date, formats, d3) => {
     return d3.timeFormat(formats.year)(date);
 };
 
-export default (d3, config, xScale) => {
+export default (d3, config, xScale, breakpoint) => {
     const {
         label: { width: labelWidth },
         axis: { formats },
         locale,
         numberDisplayedTicks,
-        breakpoints,
     } = config;
     d3.timeFormatDefaultLocale(locale);
     return selection => {
         const axis = selection.selectAll('.axis').data(d => d);
-        const breakpoint = getBreakpointLabel(breakpoints, window.innerWidth);
 
         axis.exit().remove();
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -60,7 +60,9 @@ export default (d3, config, xScale) => {
             .tickFormat(d => tickFormat(d, formats, d3));
 
         const breakpoint = getBreakpointLabel(window.innerWidth) || 'extra';
-        axisTop.ticks(numberDisplayedTicks[breakpoint]);
+        if (numberDisplayedTicks) {
+            axisTop.ticks(numberDisplayedTicks[breakpoint]);
+        }
 
         axis
             .enter()

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,14 +1,15 @@
 import { timeFormat } from 'd3-time-format';
 import breakpoints from './breakpoints';
 
-export const getBreakpointLabel = point =>
-    Object.keys(breakpoints).reduce((accumulator, label) => {
-        if (!accumulator.length && point <= breakpoints[label]) {
+export const getBreakpointLabel = point => {
+    for (const label in breakpoints) {
+        if (point <= breakpoints[label]) {
             return label;
         }
+    }
 
-        return accumulator;
-    }, '');
+    return 'extra';
+};
 
 export const tickFormat = (date, formats, d3) => {
     if (d3.timeSecond(date) < date) {
@@ -52,17 +53,14 @@ export default (d3, config, xScale) => {
     d3.timeFormatDefaultLocale(locale);
     return selection => {
         const axis = selection.selectAll('.axis').data(d => d);
+        const breakpoint = getBreakpointLabel(window.innerWidth);
 
         axis.exit().remove();
 
         const axisTop = d3
             .axisTop(xScale)
-            .tickFormat(d => tickFormat(d, formats, d3));
-
-        const breakpoint = getBreakpointLabel(window.innerWidth) || 'extra';
-        if (numberDisplayedTicks) {
-            axisTop.ticks(numberDisplayedTicks[breakpoint]);
-        }
+            .tickFormat(d => tickFormat(d, formats, d3))
+            .ticks(numberDisplayedTicks[breakpoint]);
 
         axis
             .enter()

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -22,6 +22,12 @@ const defaultConfig = {
     numberDisplayedTicks: {
         extra: 12,
     },
+    breakpoints: {
+        small: 576,
+        medium: 768,
+        large: 992,
+        extra: 1200,
+    },
 };
 
 const defaultScale = d3.scaleTime();
@@ -147,9 +153,17 @@ describe('Axis', () => {
 
 describe('Breakpoint Label', () => {
     it('should return breakpoint label correctly depending of current point', () => {
-        expect(getBreakpointLabel(400)).toBe('small');
-        expect(getBreakpointLabel(600)).toBe('medium');
-        expect(getBreakpointLabel(800)).toBe('large');
-        expect(getBreakpointLabel(1000)).toBe('extra');
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 400)).toBe(
+            'small'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 600)).toBe(
+            'medium'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 800)).toBe(
+            'large'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 1000)).toBe(
+            'extra'
+        );
     });
 });

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -1,6 +1,6 @@
 import defaultLocale from 'd3-time-format/locale/en-US.json';
 
-import axis, { tickFormat } from './axis';
+import axis, { tickFormat, getBreakpointLabel } from './axis';
 
 const defaultConfig = {
     label: {
@@ -123,5 +123,14 @@ describe('Axis', () => {
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();
+    });
+});
+
+describe('Breakpoint Label', () => {
+    it('should return breakpoint label correctly depending of current point', () => {
+        expect(getBreakpointLabel(400)).toBe('small');
+        expect(getBreakpointLabel(600)).toBe('medium');
+        expect(getBreakpointLabel(800)).toBe('large');
+        expect(getBreakpointLabel(1000)).toBe('extra');
     });
 });

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -19,6 +19,9 @@ const defaultConfig = {
             year: '%Y',
         },
     },
+    numberDisplayedTicks: {
+        extra: 12,
+    },
 };
 
 const defaultScale = d3.scaleTime();
@@ -79,7 +82,10 @@ describe('Axis', () => {
     });
 
     it('should use tick formats passed in configuration', () => {
-        const tickFormatSpy = jest.fn(() => () => {});
+        const ticksSpy = jest.fn(() => () => {});
+        const tickFormatSpy = jest.fn(() => ({
+            ticks: ticksSpy,
+        }));
         jest.spyOn(d3, 'axisTop').mockImplementation(() => ({
             tickFormat: tickFormatSpy,
         }));
@@ -120,7 +126,7 @@ describe('Axis', () => {
         expect(timeFormatDefaultLocaleSpy).toHaveBeenCalledWith(defaultLocale);
     });
 
-    it('should display tick using configuration locale', () => {
+    it('should display number of ticks passed in configuration', () => {
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
 

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -1,6 +1,6 @@
 import defaultLocale from 'd3-time-format/locale/en-US.json';
 
-import axis, { tickFormat, getBreakpointLabel } from './axis';
+import axis, { tickFormat } from './axis';
 
 const defaultConfig = {
     label: {
@@ -22,15 +22,10 @@ const defaultConfig = {
     numberDisplayedTicks: {
         extra: 12,
     },
-    breakpoints: {
-        small: 576,
-        medium: 768,
-        large: 992,
-        extra: 1200,
-    },
 };
 
 const defaultScale = d3.scaleTime();
+const defaultBreakpointLabel = 'extra';
 
 describe('Axis Tick Format', () => {
     it('should format date correctly depending of current granularity', () => {
@@ -59,21 +54,27 @@ describe('Axis', () => {
     it('should add a group with class "axis"', () => {
         const selection = d3.select('svg').data([[{}]]);
 
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
         expect(document.querySelector('.axis')).toBeTruthy();
     });
 
     it('should append only a single group regardless number of given data', () => {
         const selection = d3.select('svg').data([[{}, {}, {}]]);
 
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
         expect(document.querySelectorAll('.axis').length).toBe(1);
     });
 
     it('should be translated of `label.width` to the right', () => {
         const selection = d3.select('svg').data([[{}, {}, {}]]);
 
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
         expect(document.querySelector('.axis').getAttribute('transform')).toBe(
             'translate(200,0)'
         );
@@ -83,7 +84,9 @@ describe('Axis', () => {
         const selection = d3.select('svg').data([[{}, {}]]);
 
         const axisTopSpy = jest.spyOn(d3, 'axisTop');
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
         expect(axisTopSpy).toHaveBeenCalledWith(defaultScale);
     });
 
@@ -98,7 +101,9 @@ describe('Axis', () => {
 
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
 
         const tickFormat = tickFormatSpy.mock.calls[0][0];
         expect(tickFormat(new Date('2017-01-01 12:00:00'))).toBe('12 PM');
@@ -107,10 +112,14 @@ describe('Axis', () => {
     it('should remove "axis" group when data is removed', () => {
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
 
         selection.data([[]]);
-        axis(d3, defaultConfig, defaultScale)(selection);
+        axis(d3, defaultConfig, defaultScale, defaultBreakpointLabel)(
+            selection
+        );
         expect(document.querySelectorAll('.axis').length).toBe(0);
     });
 
@@ -127,7 +136,7 @@ describe('Axis', () => {
 
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
-        axis(d3, config, defaultScale)(selection);
+        axis(d3, config, defaultScale, defaultBreakpointLabel)(selection);
 
         expect(timeFormatDefaultLocaleSpy).toHaveBeenCalledWith(defaultLocale);
     });
@@ -141,29 +150,12 @@ describe('Axis', () => {
             numberDisplayedTicks: { extra: 9 },
         };
 
-        axis(d3, config, defaultScale)(selection);
+        axis(d3, config, defaultScale, defaultBreakpointLabel)(selection);
         expect(document.querySelectorAll('.tick').length).toBe(9);
     });
 
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();
-    });
-});
-
-describe('Breakpoint Label', () => {
-    it('should return breakpoint label correctly depending of current point', () => {
-        expect(getBreakpointLabel(defaultConfig.breakpoints, 400)).toBe(
-            'small'
-        );
-        expect(getBreakpointLabel(defaultConfig.breakpoints, 600)).toBe(
-            'medium'
-        );
-        expect(getBreakpointLabel(defaultConfig.breakpoints, 800)).toBe(
-            'large'
-        );
-        expect(getBreakpointLabel(defaultConfig.breakpoints, 1000)).toBe(
-            'extra'
-        );
     });
 });

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -137,13 +137,6 @@ describe('Axis', () => {
 
         axis(d3, config, defaultScale)(selection);
         expect(document.querySelectorAll('.tick').length).toBe(9);
-
-        config = {
-            ...defaultConfig,
-            numberDisplayedTicks: { extra: 5 },
-        };
-        axis(d3, config, defaultScale)(selection);
-        expect(document.querySelectorAll('.tick').length).toBe(5);
     });
 
     afterEach(() => {

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -120,6 +120,26 @@ describe('Axis', () => {
         expect(timeFormatDefaultLocaleSpy).toHaveBeenCalledWith(defaultLocale);
     });
 
+    it('should display tick using configuration locale', () => {
+        const data = [[{ id: 'foo' }]];
+        const selection = d3.select('svg').data(data);
+
+        let config = {
+            ...defaultConfig,
+            numberDisplayedTicks: { extra: 9 },
+        };
+
+        axis(d3, config, defaultScale)(selection);
+        expect(document.querySelectorAll('.tick').length).toBe(9);
+
+        config = {
+            ...defaultConfig,
+            numberDisplayedTicks: { extra: 5 },
+        };
+        axis(d3, config, defaultScale)(selection);
+        expect(document.querySelectorAll('.tick').length).toBe(5);
+    });
+
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();

--- a/src/breakpoint.js
+++ b/src/breakpoint.js
@@ -1,0 +1,9 @@
+export const getBreakpointLabel = (breakpoints, point) => {
+    for (const label in breakpoints) {
+        if (point <= breakpoints[label]) {
+            return label;
+        }
+    }
+
+    return 'extra';
+};

--- a/src/breakpoint.spec.js
+++ b/src/breakpoint.spec.js
@@ -1,0 +1,27 @@
+import { getBreakpointLabel } from './breakpoint';
+
+const defaultConfig = {
+    breakpoints: {
+        small: 576,
+        medium: 768,
+        large: 992,
+        extra: 1200,
+    },
+};
+
+describe('Breakpoint Label', () => {
+    it('should return breakpoint label correctly depending of current point', () => {
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 400)).toBe(
+            'small'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 600)).toBe(
+            'medium'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 800)).toBe(
+            'large'
+        );
+        expect(getBreakpointLabel(defaultConfig.breakpoints, 1000)).toBe(
+            'extra'
+        );
+    });
+});

--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -1,6 +1,0 @@
-export default {
-    small: 576,
-    medium: 768,
-    large: 992,
-    extra: 1200,
-};

--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -1,0 +1,6 @@
+export default {
+    small: 576,
+    medium: 768,
+    large: 992,
+    extra: 1200,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -62,4 +62,10 @@ export default d3 => ({
         large: 7,
         extra: 12,
     },
+    breakpoints: {
+        small: 576,
+        medium: 768,
+        large: 992,
+        extra: 1200,
+    },
 });

--- a/src/config.js
+++ b/src/config.js
@@ -56,4 +56,10 @@ export default d3 => ({
         minimumScale: 0,
         maximumScale: Infinity,
     },
+    numberDisplayedTicks: {
+        small: 3,
+        medium: 5,
+        large: 7,
+        extra: 12,
+    },
 });

--- a/src/index.js
+++ b/src/index.js
@@ -13,21 +13,11 @@ import { withinRange } from './withinRange';
 // do not export anything else here to keep window.eventDrops as a function
 export default ({ d3 = window.d3, ...customConfiguration }) => {
     const onResize = callback => {
-        if (window.attachEvent) {
-            // IE < 9
-            window.attachEvent('onresize', callback);
-        } else if (window.addEventListener) {
-            window.addEventListener('resize', callback, true);
-        }
+        window.addEventListener('resize', callback, true);
     };
 
-    const removeEventListener = callback => {
-        if (window.detachEvent) {
-            // IE < 9
-            window.detachEvent('onresize', callback);
-        } else if (window.removeEventListener) {
-            window.removeEventListener('resize', callback, true);
-        }
+    const removeOnResize = callback => {
+        window.removeEventListener('resize', callback, true);
     };
 
     const createChart = (root, selection) => {
@@ -99,12 +89,12 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
         };
 
         onResize(updateChart);
-        chart._removeEventListener = () => removeEventListener(updateChart);
+        chart._removeOnResize = () => removeOnResize(updateChart);
     };
 
     chart.scale = () => chart._scale;
     chart.filteredData = () => chart._filteredData;
-    chart.removeEventListener = () => chart._removeEventListener();
+    chart.removeOnResize = () => chart._removeOnResize();
 
     const draw = (config, scale) => selection => {
         const { drop: { date: dropDate } } = config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import defaultsDeep from 'lodash.defaultsdeep';
 
-import axis from './axis';
+import axis, { getBreakpointLabel } from './axis';
 import bounds from './bounds';
 import defaultConfiguration from './config';
 import dropLine from './dropLine';
@@ -32,6 +32,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             line: { height: lineHeight },
             range: { start: rangeStart, end: rangeEnd },
             margin,
+            breakpoints,
         } = config;
 
         const getEvent = () => d3.event; // keep d3.event mutable see https://github.com/d3/d3/issues/2733
@@ -45,6 +46,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             .range([0, width - labelWidth]);
 
         chart._scale = xScale;
+        chart._breakpoint = getBreakpointLabel(breakpoints, window.innerWidth);
 
         const svg = root
             .enter()
@@ -124,7 +126,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             .data(filteredData)
             .call(dropLine(config, scale))
             .call(bounds(config, scale))
-            .call(axis(d3, config, scale));
+            .call(axis(d3, config, scale, chart._breakpoint));
     };
 
     chart.draw = draw;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,15 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
         }
     };
 
+    const removeEventListener = callback => {
+        if (window.detachEvent) {
+            // IE < 9
+            window.detachEvent('onresize', callback);
+        } else if (window.removeEventListener) {
+            window.removeEventListener('resize', callback, true);
+        }
+    };
+
     const createChart = (root, selection) => {
         const config = defaultsDeep(
             customConfiguration || {},
@@ -84,14 +93,18 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
 
         createChart(root, selection);
 
-        onResize(() => {
+        const updateChart = () => {
             selection.selectAll('svg').remove();
             createChart(root, selection);
-        });
+        };
+
+        onResize(updateChart);
+        chart._removeEventListener = () => removeEventListener(updateChart);
     };
 
     chart.scale = () => chart._scale;
     chart.filteredData = () => chart._filteredData;
+    chart.removeEventListener = () => chart._removeEventListener();
 
     const draw = (config, scale) => selection => {
         const { drop: { date: dropDate } } = config;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ import { withinRange } from './withinRange';
 // do not export anything else here to keep window.eventDrops as a function
 export default ({ d3 = window.d3, ...customConfiguration }) => {
     const initChart = selection => {
+        selection.selectAll('svg').remove();
+
         const root = selection.selectAll('svg').data(selection.data());
         root.exit().remove();
 
@@ -73,23 +75,16 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
     };
 
     const chart = selection => {
-        initChart(selection);
+        chart._initialize = () => initChart(selection);
+        chart._initialize();
 
-        const updateChart = () => {
-            selection.selectAll('svg').remove();
-            initChart(selection);
-        };
-
-        window.addEventListener('resize', updateChart, true);
-
-        chart._removeOnResize = () =>
-            window.removeEventListener('resize', updateChart, true);
+        global.addEventListener('resize', chart._initialize, true);
     };
 
     chart.scale = () => chart._scale;
     chart.filteredData = () => chart._filteredData;
-    chart.destroy = callback => {
-        chart._removeOnResize();
+    chart.destroy = (callback = () => {}) => {
+        global.removeEventListener('resize', chart._initialize, true);
         callback();
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import defaultsDeep from 'lodash.defaultsdeep';
 
-import axis, { getBreakpointLabel } from './axis';
+import axis from './axis';
+import { getBreakpointLabel } from './breakpoint';
 import bounds from './bounds';
 import defaultConfiguration from './config';
 import dropLine from './dropLine';
@@ -46,7 +47,10 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             .range([0, width - labelWidth]);
 
         chart._scale = xScale;
-        chart._breakpoint = getBreakpointLabel(breakpoints, window.innerWidth);
+        chart.currentBreakpointLabel = getBreakpointLabel(
+            breakpoints,
+            global.innerWidth
+        );
 
         const svg = root
             .enter()
@@ -126,7 +130,7 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
             .data(filteredData)
             .call(dropLine(config, scale))
             .call(bounds(config, scale))
-            .call(axis(d3, config, scale, chart._breakpoint));
+            .call(axis(d3, config, scale, chart.currentBreakpointLabel));
     };
 
     chart.draw = draw;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -16,6 +16,7 @@ const defaultConfig = {
     margin: {},
     axis: {},
     locale: {},
+    numberDisplayedTicks: {},
 };
 
 describe('EventDrops', () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -176,6 +176,15 @@ describe('EventDrops', () => {
         ]);
     });
 
+    it('should give access to current breakpoint label', () => {
+        const chart = EventDrops(defaultConfig);
+
+        const root = d3.select('div').data([[{ data: [] }]]);
+        root.call(chart);
+
+        expect(chart.currentBreakpointLabel).toEqual('extra');
+    });
+
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();


### PR DESCRIPTION
Make responsive great again.

![responsive](https://user-images.githubusercontent.com/2212144/42310051-b37166ca-803a-11e8-9160-37316dd25352.gif)

## Todo review

- [ ] [Can't we do it in the resize event instead? We don't need to recompute it everytime if window size is kept the same.](https://github.com/marmelab/EventDrops/pull/249/files/de5fb75b7d4bc99af2f60ecaefdc53dbc029e6b1#diff-ebda1a9bff32163c25e5cf2b8a64b0a5R62)

fixes #245 

PS: Test in other PR with cypress