### PR TITLE
Fix bug 241 - drop color function or radius on zoom

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -1,7 +1,7 @@
 import uniqBy from 'lodash.uniqby';
 
 const filterOverlappingDrop = (xScale, dropDate) => d =>
-    uniqBy(d.data, data => Math.round(xScale(dropDate(data))));
+    uniqBy(d.data, data => xScale(dropDate(data)));
 
 export default (config, xScale) => selection => {
     const {
@@ -30,6 +30,10 @@ export default (config, xScale) => selection => {
         .on('mouseout', onMouseOut)
         .merge(drops)
         .attr('cx', d => xScale(dropDate(d)));
+
+    drops
+        .attr('r', dropRadius)
+        .attr('fill', dropColor);
 
     drops
         .exit()


### PR DESCRIPTION
1) Math.round() could identify the current drops date as duplicated incorrectly. In the demo data, many commits are very close and considered duplicated after Math.round();

2) drop.enter() takes care the new drops, drop.exit() takes are the removing drops. But current rendered drops are not taken care of, so color and radius are not called. 