### PR TITLE
Enhancement: Vertical grid lines (on tick) and custom tickPadding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,6 +310,8 @@ const chart = eventDrops({
 _Default: `false`_
 
 Display vertical grid lines. Height of line is equal to number of lines times height of line.
+The dropLines can be set to not show by customizing the CSS.
+![vertical grid](https://user-images.githubusercontent.com/15114362/50725403-6348da80-10fd-11e9-91f3-f1128b64d172.png)
 
 ### tickPadding
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,6 +305,18 @@ const chart = eventDrops({
 });
 ```
 
+### verticalGrid
+
+_Default: `false`_
+
+Display vertical grid lines. Height of line is equal to number of lines times height of line.
+
+### tickPadding
+
+_Default: 6_
+
+Same as D3 .tickPadding(), allows to set the padding of the tick. This is the y offset of the label for the axis.
+
 ## zoom
 
 This section is related to `zoom` (and pan) behavior. If you want to disable interactivity on your chart, just set this parameter to `false`.

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,5 +1,3 @@
-import { timeFormat } from 'd3-time-format';
-
 export const tickFormat = (date, formats, d3) => {
     if (d3.timeSecond(date) < date) {
         return d3.timeFormat(formats.milliseconds)(date);
@@ -35,9 +33,10 @@ export const tickFormat = (date, formats, d3) => {
 export default (d3, config, xScale, breakpointLabel) => {
     const {
         label: { width: labelWidth },
-        axis: { formats },
+        axis: { formats, verticalGrid, tickPadding },
         locale,
         numberDisplayedTicks,
+        line: { height: lineHeight },
     } = config;
     d3.timeFormatDefaultLocale(locale);
     return selection => {
@@ -48,10 +47,13 @@ export default (d3, config, xScale, breakpointLabel) => {
         const axisTop = d3
             .axisTop(xScale)
             .tickFormat(d => tickFormat(d, formats, d3))
-            .ticks(numberDisplayedTicks[breakpointLabel]);
+            .ticks(numberDisplayedTicks[breakpointLabel])
+            .tickPadding(tickPadding);
 
-        axis
-            .enter()
+        if (verticalGrid)
+            axisTop.tickSizeInner(-(selection.data()[0].length * lineHeight));
+
+        axis.enter()
             .filter((_, i) => !i)
             .append('g')
             .classed('axis', true)

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -18,9 +18,14 @@ const defaultConfig = {
             months: '%B',
             year: '%Y',
         },
+        verticalGrid: false,
+        tickPadding: 6,
     },
     numberDisplayedTicks: {
         extra: 12,
+    },
+    line: {
+        height: 40,
     },
 };
 
@@ -91,7 +96,10 @@ describe('Axis', () => {
     });
 
     it('should use tick formats passed in configuration', () => {
-        const ticksSpy = jest.fn(() => () => {});
+        const tickPaddingSpy = jest.fn(() => () => {});
+        const ticksSpy = jest.fn(() => ({
+            tickPadding: tickPaddingSpy,
+        }));
         const tickFormatSpy = jest.fn(() => ({
             ticks: ticksSpy,
         }));
@@ -145,7 +153,7 @@ describe('Axis', () => {
         const data = [[{ id: 'foo' }]];
         const selection = d3.select('svg').data(data);
 
-        let config = {
+        const config = {
             ...defaultConfig,
             numberDisplayedTicks: { extra: 9 },
         };

--- a/src/axis.spec.js
+++ b/src/axis.spec.js
@@ -162,6 +162,34 @@ describe('Axis', () => {
         expect(document.querySelectorAll('.tick').length).toBe(9);
     });
 
+    it('should display vertical grid lines if in configuration', () => {
+        const data = [[{ id: 'foo' }]];
+        const selection = d3.select('svg').data(data);
+
+        const config = {
+            ...defaultConfig,
+            axis: {
+                formats: {
+                    milliseconds: '.%L',
+                    seconds: ':%S',
+                    minutes: '%I:%M',
+                    hours: '%I %p',
+                    days: '%a %d',
+                    weeks: '%b %d',
+                    months: '%B',
+                    year: '%Y',
+                },
+                verticalGrid: true,
+                tickPadding: 6,
+            },
+        };
+
+        axis(d3, config, defaultScale, defaultBreakpointLabel)(selection);
+        const tickLineGroup = document.querySelectorAll('.tick line');
+        expect(tickLineGroup.length).toBe(9);
+        expect(tickLineGroup[0].attributes.y2.nodeValue).toBe('40');
+    });
+
     afterEach(() => {
         document.body.innerHTML = '';
         jest.restoreAllMocks();

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,8 @@ export default d3 => ({
             months: '%B',
             year: '%Y',
         },
+        verticalGrid: false,
+        tickPadding: 6,
     },
     drops: row => row.data,
     drop: {

--- a/src/index.js
+++ b/src/index.js
@@ -128,9 +128,9 @@ export default ({ d3 = window.d3, ...customConfiguration }) => {
 
         selection
             .data(filteredData)
+            .call(axis(d3, config, scale, chart.currentBreakpointLabel))
             .call(dropLine(config, scale))
-            .call(bounds(config, scale))
-            .call(axis(d3, config, scale, chart.currentBreakpointLabel));
+            .call(bounds(config, scale));
     };
 
     chart.draw = draw;

--- a/src/style.css
+++ b/src/style.css
@@ -4,7 +4,14 @@
     stroke-width: 1px;
 }
 
-.line-separator, .x-axis {
+.axis g.tick line {
+    stroke: #777;
+    fill: none;
+    stroke-width: 1px;
+}
+
+.line-separator,
+.x-axis {
     stroke: #777;
     fill: none;
     stroke-width: 1px;


### PR DESCRIPTION
Implemented option to add vertical grid lines. This uses the tick and adds the inner size equal to the line height times number of drop lines.
In order for the labels to stay the same without grid lines, the tickPadding is specified and can be changed to allow for more customisation.

Looks alright also a nice feature to have if there is a lot of data and you want to be able to see the difference between the data points a bit more easily.