### PR TITLE
Fixed a bug where the bounds end text disappeared.

### DIFF
--- a/src/bounds.js
+++ b/src/bounds.js
@@ -11,34 +11,28 @@ export default (config, xScale) => selection => {
 
     bounds.exit().remove();
 
-    bounds
+    const boundTextGroup = bounds
         .enter()
         .filter((_, i) => !i)
         .append('g')
         .classed('bound', true)
-        .classed('start', true)
         .attr(
             'transform',
             `translate(${labelWidth}, ${lineHeight * numberRows + margin.top})`
-        )
+        );
+
+    boundTextGroup
         .append('text')
+        .classed('start', true)
         .text(dateFormat(xScale.domain()[0]));
 
-    bounds
-        .enter()
-        .filter((_, i) => !i)
-        .append('g')
-        .classed('bound', true)
-        .classed('end', true)
-        .attr(
-            'transform',
-            `translate(${labelWidth}, ${lineHeight * numberRows + margin.top})`
-        )
+    boundTextGroup
         .append('text')
+        .classed('end', true)
         .attr('x', xScale.range()[1] - margin.right)
         .attr('text-anchor', 'end')
         .text(dateFormat(xScale.domain()[1]));
 
-    bounds.selectAll('.bound.start text').text(dateFormat(xScale.domain()[0]));
-    bounds.selectAll('.bound.end text').text(dateFormat(xScale.domain()[1]));
+    bounds.selectAll('.bound text.start').text(dateFormat(xScale.domain()[0]));
+    bounds.selectAll('.bound text.end').text(dateFormat(xScale.domain()[1]));
 };

--- a/src/bounds.spec.js
+++ b/src/bounds.spec.js
@@ -25,19 +25,19 @@ describe('Bounds', () => {
         document.body.appendChild(document.createElement('svg'));
     });
 
-    it('should add a group classed ".bound.start"', () => {
+    it('should add a group classed ".bound"', () => {
         const selection = d3.select('svg').data([[{}, {}]]);
 
         bounds(defaultConfig, defaultScale)(selection);
-        expect(document.querySelectorAll('g.bound.start').length).toBe(1);
+        expect(document.querySelectorAll('g.bound').length).toBe(1);
     });
 
-    it('should position start bound at bottom left, near the labels', () => {
+    it('should position group classed "bound" at bottom left near the labels', () => {
         const selection = d3.select('svg').data([[{}, {}, {}]]);
 
         bounds(defaultConfig, defaultScale)(selection);
 
-        const startBound = document.querySelector('g.bound.start');
+        const startBound = document.querySelector('g.bound');
         // translate(labelsWidth, three rows of data * lineHeight + margin.top)
         expect(startBound.getAttribute('transform')).toBe(
             'translate(200, 130)'
@@ -60,26 +60,16 @@ describe('Bounds', () => {
 
         bounds(config, scale)(selection);
 
-        const startBound = document.querySelector('g.bound.start');
+        const startBound = document.querySelector('g.bound text.start');
         expect(startBound.textContent).toBe('Formatted Bound');
         expect(formatStub).toHaveBeenCalledWith(new Date('2017-01-01'));
     });
 
-    it('should add a group classed ".bound.end"', () => {
+    it('should add text classed ".end" inside bound group', () => {
         const selection = d3.select('svg').data([[{}, {}]]);
 
         bounds(defaultConfig, defaultScale)(selection);
-        expect(document.querySelectorAll('g.bound.end').length).toBe(1);
-    });
-
-    it('should position start bound at bottom right', () => {
-        const selection = d3.select('svg').data([[{}, {}, {}]]);
-
-        bounds(defaultConfig, defaultScale)(selection);
-
-        const endBound = document.querySelector('g.bound.end');
-        // translate(labelsWidth, three rows of data * lineHeight + margin.top)
-        expect(endBound.getAttribute('transform')).toBe('translate(200, 130)');
+        expect(document.querySelectorAll('g.bound text.end').length).toBe(1);
     });
 
     it('should display correctly formatted scale domain end as an end bound', () => {
@@ -98,7 +88,7 @@ describe('Bounds', () => {
 
         bounds(config, scale)(selection);
 
-        const endBound = document.querySelector('g.bound.end');
+        const endBound = document.querySelector('g.bound text.end');
         expect(endBound.textContent).toBe('Formatted Bound');
         expect(formatStub).toHaveBeenCalledWith(new Date('2017-02-01'));
     });
@@ -109,7 +99,7 @@ describe('Bounds', () => {
         const scale = d3.scaleTime().range([200, 800]);
         bounds(defaultConfig, scale)(selection);
 
-        const endBound = document.querySelector('g.bound.end text');
+        const endBound = document.querySelector('g.bound text.end');
         expect(endBound.getAttribute('text-anchor')).toBe('end');
 
         // rangeEnd - marginRight


### PR DESCRIPTION
See commit for details. This fixes that the end text disappeared when scrolling/zooming.

This PR closes #240 