### PR TITLE
Zoom improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 1.4.0 (Unreleased)
+
+*   [#262](https://github.com/marmelab/EventDrops/pull/262): Fixed issue where right bound text would disappear.
+*   [#259](https://github.com/marmelab/EventDrops/pull/259): Fixed issue where color was flickering and global was undefined.
+
 ### 1.1.x
 
 **1.1.2:**

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In addition to this configuration object, it also exposes some public members al
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
-*   **zoomToDomain(domain)** programmatically zooms to domain, where domain is `[date, date]` (leftmost date, rightmost date)
+*   **zoomToDomain(domain)** programmatically zooms to domain, where domain is `[date, date]` (leftmost date, rightmost date). Ignores restrictPan modifier (default D3 behaviour).
 *   **destroy()** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 *   **currentBreakpointLabel** returns current breakpoint (for instance `small`) among a [list of breakpoints](./docs/configuration.md#breakpoints).
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ In addition to this configuration object, it also exposes some public members al
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
+*   **zoomToDomain(domain)** programmatically zooms to domain, where domain is `[date, date]` (leftmost date, rightmost date)
 *   **destroy()** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 *   **currentBreakpointLabel** returns current breakpoint (for instance `small`) among a [list of breakpoints](./docs/configuration.md#breakpoints).
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In addition to this configuration object, it also exposes some public members al
 *   **scale()** provides the horizontal scale, allowing you to retrieve bounding dates thanks to `.scale().domain()`,
 *   **filteredData()** returns an object with both `data` and `fullData` keys containing respectively bounds filtered data and full dataset.
 *   **draw(config, scale)** redraws chart using given configuration and `d3.scaleTime` scale
-*   **zoomToDomain(domain)** programmatically zooms to domain, where domain is `[date, date]` (leftmost date, rightmost date). Ignores restrictPan modifier (default D3 behaviour).
+*   **zoomToDomain(domain, duration = 0, delay = 0, ease = d3.easeLinear)** programmatically zooms to domain, where domain is `[date, date]` (leftmost date, rightmost date). Ignores restrictPan modifier (default D3 behaviour). By default there is no transition as duration is 0, however this can be tweaked to allow for a more visual appealing zoom.
 *   **destroy()** execute this function before to removing the chart from DOM. It prevents some memory leaks due to event listeners.
 *   **currentBreakpointLabel** returns current breakpoint (for instance `small`) among a [list of breakpoints](./docs/configuration.md#breakpoints).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,7 +351,13 @@ _Default: Infinity_
 
 This parameter configures the maximum zoom level available. Set it to a lower value to prevent your users from zooming in too deeply.
 
-### numberDisplayedTicks
+### restrictPan
+
+_Default: false_
+
+If set to `true` will restrict panning (dragging behaviour) to the initial date range. If minimumZoom is set to less than 1, the date range can be zoomed out be larger than the initial. However, after the zoom is less than 1, the pan behaviour is disabled.
+
+## numberDisplayedTicks
 
 \_Default:
 
@@ -368,7 +374,7 @@ const chart = eventDrops({
 
 When reducing chart width, we need to display less labels on the horizontal axis to keep a readable chart. This parameter aims to solve the issue. Hence, on smallest devices, it displays only 3 labels by default at the same time.
 
-### breakpoints
+## breakpoints
 
 \_Default:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,12 @@ const chart = eventDrops({ d3 });
 
 If you use EventDrops without any module bundler, just include D3 script before EventDrops, and everything should work out of the box.
 
+## id
+
+_Default: '' (not added to svg)_
+
+Convince to add id to the SVG element. This is especially useful if connecting to EventDrops chart together with zoom (through `zoomToDomain`).
+
 ## locale
 
 _Default: English locale_

--- a/src/config.js
+++ b/src/config.js
@@ -60,6 +60,7 @@ export default d3 => ({
         onZoomEnd: null,
         minimumScale: 0,
         maximumScale: Infinity,
+        restrictPan: false,
     },
     numberDisplayedTicks: {
         small: 3,

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import enLocale from 'd3-time-format/locale/en-US.json';
 
 export default d3 => ({
+    id: '',
     locale: enLocale,
     metaballs: {
         blurDeviation: 10,

--- a/src/index.js
+++ b/src/index.js
@@ -64,13 +64,27 @@ export default ({
             .attr('width', width)
             .classed('event-drop-chart', true);
 
+        const height = parseFloat(svg.style('height'));
+
         if (id) {
             svg.attr('id', id);
         }
 
         if (zoomConfig) {
             const zoomObject = d3.zoom();
-            svg.call(zoom(d3, svg, config, zoomObject, xScale, draw, getEvent));
+            svg.call(
+                zoom(
+                    d3,
+                    svg,
+                    config,
+                    zoomObject,
+                    xScale,
+                    draw,
+                    getEvent,
+                    width,
+                    height
+                )
+            );
 
             chart._zoomToDomain = domain => {
                 const zoomIdentity = getDomainTransform(

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ export default ({
                 )
             );
 
-            chart._zoomToDomain = domain => {
+            chart._zoomToDomain = (domain, duration, delay, ease) => {
                 const zoomIdentity = getDomainTransform(
                     d3,
                     config,
@@ -95,7 +95,12 @@ export default ({
                     xScale,
                     width
                 );
-                svg.call(zoomObject.transform, zoomIdentity);
+                svg
+                    .transition()
+                    .ease(ease)
+                    .delay(delay)
+                    .duration(duration)
+                    .call(zoomObject.transform, zoomIdentity);
             };
         }
 
@@ -126,9 +131,14 @@ export default ({
 
     chart.scale = () => chart._scale;
     chart.filteredData = () => chart._filteredData;
-    chart.zoomToDomain = domain => {
+    chart.zoomToDomain = (
+        domain,
+        duration = 0,
+        delay = 0,
+        ease = d3.easeLinear
+    ) => {
         if (chart._zoomToDomain) {
-            chart._zoomToDomain(domain);
+            chart._zoomToDomain(domain, duration, delay, ease);
         }
     };
     chart.destroy = (callback = () => {}) => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -24,6 +24,22 @@ describe('EventDrops', () => {
         resetDom();
     });
 
+    it('should add id if present in config', () => {
+        const config = {
+            ...defaultConfig,
+            id: 'test_id',
+        };
+
+        const chart = EventDrops(config);
+
+        const root = d3.select('div').data([[{ data: [] }]]);
+
+        root.call(chart);
+        const svg = document.querySelector('svg');
+
+        expect(svg.attributes.id.value).toEqual('test_id');
+    });
+
     it('should enable zoom if and only if zoomConfig is not falsy', () => {
         const test = (zoomConfig, shouldZoomBeCalled) => {
             resetDom();
@@ -59,6 +75,24 @@ describe('EventDrops', () => {
             new Date('2011-01-01'),
         ]);
     });
+
+    // it('should zoom to correct domain on zoomToDomain', () => {
+    //     const chart = EventDrops({
+    //         zoom: {},
+    //         range: {
+    //             start: new Date('2010-01-01'),
+    //             end: new Date('2011-01-01'),
+    //         },
+    //     });
+    //
+    //     const root = d3.select('div').data([[{ data: [] }]]);
+    //     root.call(chart);
+    //
+    //     const domain = [new Date('2010-04-01'), new Date('2010-09-01')];
+    //     chart.zoomToDomain(domain);
+    //
+    //     expect(chart.scale().domain()).toEqual(domain);
+    // });
 
     it('should allow to select custom data properties', () => {
         const chart = EventDrops({

--- a/src/isAfter.js
+++ b/src/isAfter.js
@@ -3,6 +3,5 @@ import dateIsAfter from 'date-fns/is_after';
 export const isAfter = (date, dateBounds) => {
     const endingDate = Math.max(...dateBounds);
 
-    // @TODO: remove the `new Date()` constructor in the next major version: we need to force it at configuration level.
-    return dateIsAfter(new Date(date), endingDate);
+    return dateIsAfter(date, endingDate);
 };

--- a/src/isAfter.spec.js
+++ b/src/isAfter.spec.js
@@ -7,11 +7,11 @@ describe('isAfter', () => {
             expect(isAfter(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-05-19', true);
-        test('2018-05-01', false);
-        test('2018-04-19', false);
-        test('2018-04-01', false);
-        test('2018-01-01', false);
+        test(new Date('2018-05-19'), true);
+        test(new Date('2018-05-01'), false);
+        test(new Date('2018-04-19'), false);
+        test(new Date('2018-04-01'), false);
+        test(new Date('2018-01-01'), false);
     });
 
     it('should return true if date is after given reverse date range (start date older than end date)', () => {
@@ -20,10 +20,10 @@ describe('isAfter', () => {
             expect(isAfter(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-05-19', true);
-        test('2018-05-01', false);
-        test('2018-04-19', false);
-        test('2018-04-01', false);
-        test('2018-01-01', false);
+        test(new Date('2018-05-19'), true);
+        test(new Date('2018-05-01'), false);
+        test(new Date('2018-04-19'), false);
+        test(new Date('2018-04-01'), false);
+        test(new Date('2018-01-01'), false);
     });
 });

--- a/src/isBefore.js
+++ b/src/isBefore.js
@@ -3,6 +3,5 @@ import dateIsBefore from 'date-fns/is_before';
 export const isBefore = (date, dateBounds) => {
     const startingDate = Math.min(...dateBounds);
 
-    // @TODO: remove the `new Date()` constructor in the next major version: we need to force it at configuration level.
-    return dateIsBefore(new Date(date), startingDate);
+    return dateIsBefore(date, startingDate);
 };

--- a/src/isBefore.spec.js
+++ b/src/isBefore.spec.js
@@ -7,11 +7,11 @@ describe('isBefore', () => {
             expect(isBefore(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-01-01', true);
-        test('2018-05-19', false);
-        test('2018-05-01', false);
-        test('2018-04-19', false);
-        test('2018-04-01', false);
+        test(new Date('2018-01-01'), true);
+        test(new Date('2018-05-19'), false);
+        test(new Date('2018-05-01'), false);
+        test(new Date('2018-04-19'), false);
+        test(new Date('2018-04-01'), false);
     });
 
     it('should return true if date is before given reverse date range (start date older than end date)', () => {
@@ -20,10 +20,10 @@ describe('isBefore', () => {
             expect(isBefore(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-01-01', true);
-        test('2018-05-19', false);
-        test('2018-05-01', false);
-        test('2018-04-19', false);
-        test('2018-04-01', false);
+        test(new Date('2018-01-01'), true);
+        test(new Date('2018-05-19'), false);
+        test(new Date('2018-05-01'), false);
+        test(new Date('2018-04-19'), false);
+        test(new Date('2018-04-01'), false);
     });
 });

--- a/src/withinRange.js
+++ b/src/withinRange.js
@@ -4,6 +4,5 @@ export const withinRange = (date, dateBounds) => {
     const startingDate = Math.min(...dateBounds);
     const endingDate = Math.max(...dateBounds);
 
-    // @TODO: remove the `new Date()` constructor in the next major version: we need to force it at configuration level.
-    return isWithinRange(new Date(date), startingDate, endingDate);
+    return isWithinRange(date, startingDate, endingDate);
 };

--- a/src/withinRange.spec.js
+++ b/src/withinRange.spec.js
@@ -7,10 +7,10 @@ describe('withinRange', () => {
             expect(withinRange(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-04-19', true);
-        test('2018-04-01', true);
-        test('2018-05-01', true);
-        test('2018-05-19', false);
+        test(new Date('2018-04-19'), true);
+        test(new Date('2018-04-01'), true);
+        test(new Date('2018-05-01'), true);
+        test(new Date('2018-05-19'), false);
     });
 
     it('should return true if date is in given reverse date range (start date older than end date)', () => {
@@ -19,9 +19,9 @@ describe('withinRange', () => {
             expect(withinRange(date, dateRange)).toBe(expectedResult);
         };
 
-        test('2018-04-19', true);
-        test('2018-04-01', true);
-        test('2018-05-01', true);
-        test('2018-05-19', false);
+        test(new Date('2018-04-19'), true);
+        test(new Date('2018-04-01'), true);
+        test(new Date('2018-05-01'), true);
+        test(new Date('2018-05-19'), false);
     });
 });

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -27,13 +27,40 @@ export function getDomainTransform(d3, config, zoom, domain, xScale, width) {
         .translate(-fullLabelWidth, 0);
 }
 
-export default (d3, svg, config, zoom, xScale, draw, getEvent) => {
+export default (
+    d3,
+    svg,
+    config,
+    zoom,
+    xScale,
+    draw,
+    getEvent,
+    width,
+    height
+) => {
     const {
         label: { width: labelsWidth, padding: labelsPadding },
-        zoom: { onZoomStart, onZoom, onZoomEnd, minimumScale, maximumScale },
+        zoom: {
+            onZoomStart,
+            onZoom,
+            onZoomEnd,
+            minimumScale,
+            maximumScale,
+            restrictPan,
+        },
     } = config;
 
+    const extentConstraint = [
+        [labelsWidth + labelsPadding, 0],
+        [width, height],
+    ];
+
     zoom.scaleExtent([minimumScale, maximumScale]);
+
+    //Restricts the pan area to be the specified start/end dates or initial if not set
+    if (restrictPan) {
+        zoom.translateExtent(extentConstraint).extent(extentConstraint);
+    }
 
     zoom.on('zoom.start', onZoomStart).on('zoom.end', onZoomEnd);
 

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -15,13 +15,25 @@ export const getShiftedTransform = (
         .translate(labelsWidth + labelsPadding, 0); // put origin at its original position
 };
 
-export default (d3, svg, config, xScale, draw, getEvent) => {
+export function getDomainTransform(d3, config, zoom, domain, xScale, width) {
+    const { label: { width: labelsWidth, padding: labelsPadding } } = config;
+
+    const fullLabelWidth = labelsWidth + labelsPadding;
+    // For the reason of two additional translate see getShiftedTransform for explanation
+    return d3.zoomIdentity
+        .translate(fullLabelWidth, 0)
+        .scale((width - labelsWidth) / (xScale(domain[1]) - xScale(domain[0])))
+        .translate(-xScale(domain[0]), 0)
+        .translate(-fullLabelWidth, 0);
+}
+
+export default (d3, svg, config, zoom, xScale, draw, getEvent) => {
     const {
         label: { width: labelsWidth, padding: labelsPadding },
         zoom: { onZoomStart, onZoom, onZoomEnd, minimumScale, maximumScale },
     } = config;
 
-    const zoom = d3.zoom().scaleExtent([minimumScale, maximumScale]);
+    zoom.scaleExtent([minimumScale, maximumScale]);
 
     zoom.on('zoom.start', onZoomStart).on('zoom.end', onZoomEnd);
 

--- a/src/zoom.spec.js
+++ b/src/zoom.spec.js
@@ -78,6 +78,41 @@ describe('Zoom', () => {
         expect(zoom.scaleExtent()).toEqual([15, 25]);
     });
 
+    it('should set translate extent if restrictPan is true', () => {
+        const test = (config, translateExtent) => {
+            const width = 500,
+                height = 300;
+
+            const selection = d3.select('svg');
+            const zoomRestrict = zoomFactory(
+                d3,
+                selection,
+                config,
+                d3.zoom(),
+                {},
+                {},
+                {},
+                width,
+                height
+            );
+
+            expect(zoomRestrict.translateExtent()).toEqual(translateExtent);
+        };
+
+        const config = {
+            ...defaultConfig,
+            label: {
+                width: 100,
+                padding: 20,
+            },
+        };
+
+        test(config, [[-Infinity, -Infinity], [Infinity, Infinity]]);
+
+        config.zoom.restrictPan = true;
+        test(config, [[120, 0], [500, 300]]);
+    });
+
     /* These tests are skipped as I can't find any way to test D3 event at this point. */
     it('should update scale according to given D3 zoom event');
     it('should redraw chart using newly zoomed scale');

--- a/src/zoom.spec.js
+++ b/src/zoom.spec.js
@@ -1,4 +1,4 @@
-import zoomFactory, { getShiftedTransform } from './zoom';
+import zoomFactory, { getShiftedTransform, getDomainTransform } from './zoom';
 
 const defaultConfig = {
     label: {},
@@ -10,7 +10,7 @@ describe('Zoom', () => {
         document.body.appendChild(document.createElement('svg'));
     });
 
-    describe('getShiftedTransform', () => {
+    it('should correct shifted transform given original transform', () => {
         const originalTransform = {
             x: -120,
             y: 0,
@@ -28,6 +28,41 @@ describe('Zoom', () => {
         );
     });
 
+    it('should transform correctly given domain', () => {
+        const config = {
+            ...defaultConfig,
+            zoom: {
+                minimumScale: 15,
+                maximumScale: 25,
+            },
+            label: { width: 100, padding: 50 },
+        };
+
+        const rangeStartEnd = [new Date(2016, 0, 1), new Date(2019, 0, 1)];
+        const xScale = d3
+            .scaleTime()
+            .domain(rangeStartEnd)
+            .range([0, 100]);
+
+        const width = 400;
+        const zoomObject = d3.zoom();
+        const domain = [new Date(2017, 0, 1), new Date(2018, 0, 1)];
+        const zoomIdentity = getDomainTransform(
+            d3,
+            config,
+            zoomObject,
+            domain,
+            xScale,
+            width
+        );
+
+        expect(zoomIdentity).toEqual({
+            k: 9.008219178082191,
+            x: -1502.054794520548,
+            y: 0,
+        });
+    });
+
     it('should set scale extent based on given configuration', () => {
         const config = {
             ...defaultConfig,
@@ -37,8 +72,9 @@ describe('Zoom', () => {
             },
         };
 
+        const zoomObject = d3.zoom();
         const selection = d3.select('svg');
-        const zoom = zoomFactory(d3, selection, config);
+        const zoom = zoomFactory(d3, selection, config, zoomObject);
         expect(zoom.scaleExtent()).toEqual([15, 25]);
     });
 


### PR DESCRIPTION
So here is a feature that has been requested a lot; zoom programmatically!

Changes:
* Added ID in the config to be able to set this on the SVG element. I found this quite useful when zooming programmatically.
* ZoomToDomain function. Takes in a domain and zooms to it. Ignores any restrictions to scale or translate (as default by D3). There are also optional arguments so it is possible to do transitions to have a neat effect. I did not manage to test the function itself, as when I tried, it says that SVGElement is unknown🤷🏼‍♂️
* Restrict panning. Default false as not to break backwards compatibility. If this is set, one cannot pan outside the start and end ranges (or what is set by default). If minimumScale on zoom is less than 1, you can zoom out, however, you won't be able to pan
* Removed redundant `new Date()` in isAfter, isBefore and withingRange.

Would be great if this PR could make it into master and then prepare this for a 1.4.0 release (as the bug fixes earlier are quite important in my opinion).

Closes #268, closes #260, closes #112, closes #88, closes #236, closes #168
Issues that were fixed in earlier PR: closes #246, 