### PR TITLE
Label tooltip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
+dist: xenial
 language: node_js
 node_js:
-    - 6.9
+  - 10.15.3
 addons:
-    firefox: "50.0.2"
+  firefox: latest
 cache:
   directories:
     - node_modules
@@ -14,8 +15,8 @@ install:
   - npm install
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 script:
   - make test
+services:
+  - xvfb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 1.4.0 (Unreleased)
+
+[#270](https://github.com/marmelab/EventDrops/pull/270): Added `onMouseOver`, `onMouseOut` and `onClick` to label text.
+
 ### 1.1.x
 
 **1.1.2:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,60 @@ const chart = eventDrops({
 });
 ```
 
+### onMouseOver
+
+_Default: () => {}_
+
+Function to be executed when user moves the mouse on a label. By default, it does nothing. The object for that dropLine is passed as the first argument:
+
+```js
+const chart = eventDrops({
+    label: {
+        onMouseOver: label => {
+            showTooltip(label);
+        },
+    },
+});
+```
+
+Where `label` argument is the `{ "name": "EventDrops, "data": [...] }` etc. depending on configuration.
+
+This is the function you are looking for if you want to display a tooltip describing the label (either in detail or due to too long name).
+
+### onMouseOut
+
+_Default: () => {}_
+
+Function to be executed when user moves the mouse out of a label. By default, it does nothing. The object for that dropLine is passed as the first argument:
+
+```js
+const chart = eventDrops({
+    label: {
+        onMouseOut: label => {
+            hideTooltip(label);
+        },
+    },
+});
+```
+
+This is the function you are looking for if you want to hide a tooltip you previously displayed with `onMouseOver`.
+
+### onClick
+
+_Default: () => {}_
+
+Function to be executed when user clicks on a label. By default, it does nothing. The object for that dropLine is passed as the first argument:
+
+```js
+const chart = eventDrops({
+    label: {
+        onClick: label => {
+            Console.log(`${label} data is clicked.`);
+        },
+    },
+});
+```
+
 ## indicator
 
 _Default: indicator configuration object_

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,9 @@ export default d3 => ({
     label: {
         padding: 20,
         text: d => `${d.name} (${d.data.length})`,
+        onMouseOver: () => {},
+        onMouseOut: () => {},
+        onClick: () => {},
         width: 200,
     },
     indicator: {

--- a/src/dropLine.js
+++ b/src/dropLine.js
@@ -4,7 +4,14 @@ import indicator from './indicator';
 export default (config, xScale) => selection => {
     const {
         metaballs,
-        label: { text: labelText, padding: labelPadding, width: labelWidth },
+        label: {
+            text: labelText,
+            padding: labelPadding,
+            onMouseOver: labelOnMouseOver,
+            onMouseOut: labelOnMouseOut,
+            onClick: labelOnClick,
+            width: labelWidth,
+        },
         line: { color: lineColor, height: lineHeight },
         indicator: indicatorEnabled,
     } = config;
@@ -51,7 +58,10 @@ export default (config, xScale) => selection => {
         .attr('y', lineHeight / 2)
         .attr('dy', '0.25em')
         .attr('text-anchor', 'end')
-        .text(labelText);
+        .text(labelText)
+        .on('mouseover', labelOnMouseOver)
+        .on('mouseout', labelOnMouseOut)
+        .on('click', labelOnClick);
 
     lines.selectAll('.line-label').text(labelText);
     lines.selectAll('.drops').call(drop(config, xScale));

--- a/src/dropLine.spec.js
+++ b/src/dropLine.spec.js
@@ -1,6 +1,4 @@
 import dropLine from './dropLine';
-import indicator from './indicator';
-import drop from './drop';
 
 const defaultConfig = {
     metaballs: true,

--- a/src/dropLine.spec.js
+++ b/src/dropLine.spec.js
@@ -1,5 +1,6 @@
 import dropLine from './dropLine';
 import indicator from './indicator';
+import drop from './drop';
 
 const defaultConfig = {
     metaballs: true,
@@ -211,6 +212,99 @@ describe('Drop Line', () => {
             expect(textIndex).not.toBe(-1);
             expect(dropsIndex).not.toBe(-1);
             expect(textIndex > dropsIndex).toBe(true);
+        });
+
+        it('should call `onMouseOver` configuration listener when hovering a label', () => {
+            const selection = d3.select('svg').data([[{ name: 'foo' }]]);
+
+            const config = {
+                ...defaultConfig,
+                label: {
+                    ...defaultConfig.label,
+                    onMouseOver: jest.fn(),
+                },
+            };
+
+            dropLine(config, defaultScale)(selection);
+
+            const labelElement = d3.select('.line-label').node();
+            const event = new MouseEvent('SVGEvents', {});
+            event.initMouseEvent(
+                'mouseover',
+                true,
+                true,
+                global,
+                0,
+                10,
+                10,
+                10,
+                10,
+                false,
+                false,
+                false,
+                false,
+                null,
+                labelElement
+            );
+            labelElement.dispatchEvent(event);
+
+            expect(config.label.onMouseOver).toHaveBeenCalled();
+        });
+
+        it('should call `onMouseOut` configuration listener when blurring a label', () => {
+            const selection = d3.select('svg').data([[{ name: 'foo' }]]);
+
+            const config = {
+                ...defaultConfig,
+                label: {
+                    ...defaultConfig.label,
+                    onMouseOut: jest.fn(),
+                },
+            };
+
+            dropLine(config, defaultScale)(selection);
+
+            const labelElement = d3.select('.line-label').node();
+            const event = new MouseEvent('SVGEvents', {});
+            event.initMouseEvent(
+                'mouseout',
+                true,
+                true,
+                global,
+                0,
+                10,
+                10,
+                10,
+                10,
+                false,
+                false,
+                false,
+                false,
+                null,
+                labelElement
+            );
+            labelElement.dispatchEvent(event);
+
+            expect(config.label.onMouseOut).toHaveBeenCalled();
+        });
+
+        it('should call `onClick` configuration listener when clicking on label', () => {
+            const selection = d3.select('svg').data([[{ name: 'foo' }]]);
+
+            const config = {
+                ...defaultConfig,
+                label: {
+                    ...defaultConfig.label,
+                    onClick: jest.fn(),
+                },
+            };
+
+            dropLine(config, defaultScale)(selection);
+
+            const labelElement = d3.select('.line-label').node();
+            labelElement.click();
+
+            expect(config.label.onClick).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Exposed `onMouseOver`, `onMouseOut` and `onClick` events to the config. This allows adding tooltip for label quite easily.

Might include an example of this once I got time or maybe modifying the existing Demo to showcase this?